### PR TITLE
Implement Deck Navigation with vim/emacs Key Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ with text files and version control.
 - **Cross-Platform**: Works on Linux, macOS, and Windows
 - **Spaced Repetition Algorithm**: Implements the SM-2 algorithm for efficient learning
 - **Real-time File Watching**: Changes to card files are automatically detected and loaded
+- **Hierarchical Deck Navigation**: Browse your decks with vim and emacs keybindings
 - **Code-Focused**: Special features for programming-related cards:
   - Syntax highlighting for 50+ languages
   - Side-by-side diff view for comparing code
@@ -74,9 +75,13 @@ github.com/DavidMiserak/GoCard/
 │   │       ├── markdown.go          # Markdown parsing
 │   │       └── formatter.go         # Markdown formatting
 │   └── ui/                          # Terminal user interface
-│       ├── input/                   # Input handling
+│       ├── input/                   # Input handling and key bindings
 │       ├── render/                  # Rendering utilities
 │       └── views/                   # Screen components
+│           ├── deck_browser_view.go # Deck content browser
+│           ├── deck_list_view.go    # Hierarchical deck navigation
+│           ├── review_view.go       # Card review interface
+│           └── views.go             # View interfaces and common code
 ├── assets/                          # Application resources
 └── docs/                            # Documentation
 ```
@@ -218,6 +223,24 @@ Organize your cards however you want! The directory structure becomes the deck s
     └── german.md
 ```
 
+## Deck Navigation
+
+GoCard lets you browse your deck hierarchy with an intuitive navigation interface:
+
+1. Press `c` from any screen to enter the deck navigation view
+2. Navigate between decks using arrow keys or vim/emacs keybindings
+3. Press `Enter` to select a deck or `Esc` to go back
+
+The deck navigation shows useful information for each deck:
+- Number of cards in the deck (including subdecks)
+- Number of cards due for review
+- Visual breadcrumb trail showing your current location
+
+Keyboard shortcuts make navigation efficient:
+- Arrow keys, `j`/`k` (vim), or `Ctrl+n`/`Ctrl+p` (emacs) to move up/down
+- `Enter`, `l` (vim), or `Ctrl+f` (emacs) to select a deck
+- `Esc`, `h` (vim), or `Ctrl+b` (emacs) to go back
+
 ## Spaced Repetition System
 
 GoCard implements the SM-2 algorithm for spaced repetition, similar to
@@ -243,16 +266,21 @@ GoCard provides a clean, minimalist terminal interface optimized for focused lea
 
 ## Keyboard Shortcuts
 
-| Key     | Action              |
-|---------|---------------------|
-| `Space` | Show answer         |
-| `0-5`   | Rate card difficulty|
-| `c`     | Change deck         |
-| `C`     | Create new deck     |
-| `n`     | Create new card     |
-| `s`     | Search cards        |
-| `?`     | Toggle help         |
-| `q`     | Quit                |
+| Key                  | Action                     |
+|----------------------|----------------------------|
+| `Space`              | Show answer                |
+| `0-5`                | Rate card difficulty       |
+| `c`                  | Change deck                |
+| `C`                  | Create new deck            |
+| `n`                  | Create new card            |
+| `s`                  | Search cards               |
+| `?`                  | Toggle help                |
+| `q`                  | Quit                       |
+| **Navigation Keys**  |                            |
+| `↑/k/Ctrl+p`         | Move up in lists           |
+| `↓/j/Ctrl+n`         | Move down in lists         |
+| `Enter/l/Ctrl+f`     | Select/move forward        |
+| `Esc/h/Ctrl+b`       | Go back                    |
 
 Additional shortcuts planned for future versions:
 

--- a/internal/ui/tui.go
+++ b/internal/ui/tui.go
@@ -98,9 +98,17 @@ func (m TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case input.KeyMatches(msg, m.keys.Back):
 			// Handle going back to previous view if we're not in the main view
 			if m.currentView.State() != views.ViewDeckBrowser && m.previousView != nil {
-				m.currentView = m.previousView
-				m.previousView = nil
-				return m, nil
+				// Special handling for deck list view to ensure we return to proper deck browser
+				if m.currentView.State() == views.ViewDeckList {
+					// We should go back to deck browser for current deck
+					// The deck list view will handle this internally
+					// The view update below will take care of it
+				} else {
+					// For other views, switch back to previous view
+					m.currentView = m.previousView
+					m.previousView = nil
+					return m, nil
+				}
 			}
 		}
 

--- a/internal/ui/views/deck_browser_view.go
+++ b/internal/ui/views/deck_browser_view.go
@@ -74,8 +74,13 @@ func (v *DeckBrowserView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd)
 			return reviewView, reviewView.Init()
 
 		case input.KeyMatches(msg, keys.ChangeDeck):
-			// This would launch the deck list view
-			v.SetError("Deck list view not yet implemented in refactored version")
+			// Launch the deck list view for deck navigation
+			deckListView, err := NewDeckListView(v.store, v.currentDeck.PathFromRoot(), v.width, v.height)
+			if err != nil {
+				v.SetError(fmt.Sprintf("Error opening deck list: %v", err))
+				return v, nil
+			}
+			return deckListView, deckListView.Init()
 
 		case input.KeyMatches(msg, keys.New):
 			// This would launch the create card view

--- a/internal/ui/views/deck_list_view.go
+++ b/internal/ui/views/deck_list_view.go
@@ -1,0 +1,347 @@
+// Package views contains the different UI views for GoCard.
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/DavidMiserak/GoCard/internal/deck"
+	"github.com/DavidMiserak/GoCard/internal/storage"
+	"github.com/DavidMiserak/GoCard/internal/ui/input"
+	"github.com/DavidMiserak/GoCard/internal/ui/render"
+)
+
+// DeckListView handles the deck selection interface
+type DeckListView struct {
+	BaseView
+	store        *storage.CardStore
+	renderer     *render.Renderer
+	currentDeck  *deck.Deck             // Current directory/deck being viewed
+	visibleDecks []*deck.Deck           // List of visible decks in current view
+	cursor       int                    // Current cursor position in the list
+	breadcrumbs  []*deck.Deck           // Breadcrumb trail for navigation
+	stats        map[string]interface{} // Store statistics for the current deck
+}
+
+// NewDeckListView creates a new deck list view
+func NewDeckListView(store *storage.CardStore, currentDeckPath string, width, height int) (*DeckListView, error) {
+	baseView := NewBaseView(ViewDeckList, width, height)
+
+	renderer, err := render.NewRenderer(width)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the current deck from the path or use root deck
+	var currentDeck *deck.Deck
+	if currentDeckPath == "" {
+		currentDeck = store.RootDeck
+	} else {
+		currentDeck, err = store.GetDeckByRelativePath(currentDeckPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Initialize the deck list view
+	view := &DeckListView{
+		BaseView:    baseView,
+		store:       store,
+		renderer:    renderer,
+		currentDeck: currentDeck,
+		cursor:      0,
+		breadcrumbs: []*deck.Deck{},
+	}
+
+	// Initialize the breadcrumbs
+	view.initBreadcrumbs(currentDeck)
+
+	// Update the visible decks and viewport content
+	view.updateVisibleDecks()
+	view.updateViewport()
+
+	return view, nil
+}
+
+// initBreadcrumbs creates breadcrumb navigation path from root to current deck
+func (v *DeckListView) initBreadcrumbs(deckObj *deck.Deck) {
+	// Start with an empty breadcrumb trail
+	v.breadcrumbs = []*deck.Deck{}
+
+	// If we're at the root, no breadcrumbs needed
+	if deckObj == v.store.RootDeck {
+		return
+	}
+
+	// Build a list of decks from current to root
+	var path []*deck.Deck
+	current := deckObj
+	for current != nil && current != v.store.RootDeck {
+		path = append([]*deck.Deck{current}, path...)
+		current = current.ParentDeck
+	}
+
+	// Set the breadcrumbs
+	v.breadcrumbs = path
+}
+
+// updateVisibleDecks refreshes the list of decks shown in the current view
+func (v *DeckListView) updateVisibleDecks() {
+	// Start with the parent deck if it exists (for "Back" option)
+	v.visibleDecks = []*deck.Deck{}
+
+	// Add the parent deck as a navigation option if we're not at root
+	if v.currentDeck != v.store.RootDeck && v.currentDeck.ParentDeck != nil {
+		v.visibleDecks = append(v.visibleDecks, v.currentDeck.ParentDeck)
+	}
+
+	// Add all subdecks of the current deck
+	for _, subDeck := range v.currentDeck.SubDecks {
+		v.visibleDecks = append(v.visibleDecks, subDeck)
+	}
+
+	// Reset cursor position to prevent out-of-bounds errors
+	if len(v.visibleDecks) > 0 {
+		if v.cursor >= len(v.visibleDecks) {
+			v.cursor = len(v.visibleDecks) - 1
+		}
+	} else {
+		v.cursor = 0
+	}
+
+	// Fetch statistics for the current deck
+	v.stats = v.store.GetDeckStats(v.currentDeck)
+}
+
+// Init implements View.Init
+func (v *DeckListView) Init() tea.Cmd {
+	return nil
+}
+
+// Update implements View.Update
+func (v *DeckListView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case input.KeyMatches(msg, keys.Quit):
+			return v, tea.Quit
+
+		case input.KeyMatches(msg, keys.Back):
+			// Go back to the deck browser view
+			deckView, err := NewDeckBrowserView(v.store, v.currentDeck.PathFromRoot(), v.width, v.height)
+			if err != nil {
+				v.SetError(fmt.Sprintf("Error returning to deck browser: %v", err))
+				return v, nil
+			}
+			return deckView, deckView.Init()
+
+		case input.KeyMatches(msg, keys.ShowAnswer): // Use space or enter to select
+			fallthrough
+		case msg.String() == "enter":
+			fallthrough
+		case msg.String() == "l": // vim right
+			fallthrough
+		case msg.String() == "ctrl+f": // emacs forward
+			// Handle selection based on cursor position
+			if len(v.visibleDecks) > 0 {
+				selectedDeck := v.visibleDecks[v.cursor]
+
+				// If first item is parent (Back option)
+				if v.currentDeck != v.store.RootDeck && v.currentDeck.ParentDeck != nil && v.cursor == 0 {
+					// Navigate up to parent deck
+					v.currentDeck = selectedDeck
+					v.initBreadcrumbs(v.currentDeck)
+					v.updateVisibleDecks()
+					v.updateViewport()
+					return v, nil
+				} else {
+					// Navigate into selected subdeck
+					v.currentDeck = selectedDeck
+					v.initBreadcrumbs(v.currentDeck)
+					v.updateVisibleDecks()
+					v.updateViewport()
+					return v, nil
+				}
+			}
+
+		case msg.String() == "up":
+			fallthrough
+		case msg.String() == "k": // vim up
+			fallthrough
+		case msg.String() == "ctrl+p": // emacs previous
+			// Move cursor up
+			if v.cursor > 0 {
+				v.cursor--
+				v.updateViewport()
+			}
+
+		case msg.String() == "down":
+			fallthrough
+		case msg.String() == "j": // vim down
+			fallthrough
+		case msg.String() == "ctrl+n": // emacs next
+			// Move cursor down
+			if v.cursor < len(v.visibleDecks)-1 {
+				v.cursor++
+				v.updateViewport()
+			}
+
+		case msg.String() == "h": // vim left
+			fallthrough
+		case msg.String() == "ctrl+b": // emacs back
+			// Go back - same as Esc
+			deckView, err := NewDeckBrowserView(v.store, v.currentDeck.PathFromRoot(), v.width, v.height)
+			if err != nil {
+				v.SetError(fmt.Sprintf("Error returning to deck browser: %v", err))
+				return v, nil
+			}
+			return deckView, deckView.Init()
+
+		case input.KeyMatches(msg, keys.ChangeDeck):
+			// Same as Back - return to deck browser for current deck
+			deckView, err := NewDeckBrowserView(v.store, v.currentDeck.PathFromRoot(), v.width, v.height)
+			if err != nil {
+				v.SetError(fmt.Sprintf("Error returning to deck browser: %v", err))
+				return v, nil
+			}
+			return deckView, deckView.Init()
+		}
+
+	case tea.WindowSizeMsg:
+		v.SetDimensions(msg.Width, msg.Height)
+		if err := v.renderer.UpdateWidth(msg.Width); err != nil {
+			v.SetError(fmt.Sprintf("Error updating renderer: %v", err))
+		}
+		v.updateViewport()
+	}
+
+	v.viewport, cmd = v.viewport.Update(msg)
+	return v, cmd
+}
+
+// Render implements View.Render
+func (v *DeckListView) Render(width, height int) string {
+	var sb strings.Builder
+
+	// Render header
+	headerText := fmt.Sprintf("GoCard - Select Deck - %s", v.currentDeck.FullName())
+	sb.WriteString(v.renderer.HeaderStyle(headerText))
+	sb.WriteString("\n")
+
+	// Render error if present
+	if v.GetError() != "" {
+		sb.WriteString(v.renderer.ErrorStyle(v.GetError()))
+		sb.WriteString("\n")
+	}
+
+	// Render main content
+	sb.WriteString(v.viewport.View())
+	sb.WriteString("\n")
+
+	// Render footer - now with vim/emacs keys
+	footerText := "↑/j/k: Navigate • Enter/l: Select • Esc/h: Back • c: View Deck • ?: Help"
+	sb.WriteString(v.renderer.FooterStyle(footerText))
+
+	return sb.String()
+}
+
+// updateViewport updates the viewport content based on the deck list
+func (v *DeckListView) updateViewport() {
+	styles := v.renderer.GetStyles()
+
+	var content strings.Builder
+
+	// Breadcrumb navigation
+	breadcrumbPath := "Root"
+	if len(v.breadcrumbs) > 0 {
+		paths := []string{"Root"}
+		for _, d := range v.breadcrumbs {
+			paths = append(paths, d.Name)
+		}
+		breadcrumbPath = strings.Join(paths, " > ")
+	}
+
+	content.WriteString(styles.Subtle.Render(breadcrumbPath))
+	content.WriteString("\n\n")
+
+	// Current deck info - more compact formatting
+	content.WriteString(styles.Title.Render("# "+v.currentDeck.Name) + "\n")
+
+	if totalCards, ok := v.stats["total_cards"].(int); ok && totalCards > 0 {
+		content.WriteString(fmt.Sprintf("• Cards: %d total, %d due\n",
+			totalCards, v.stats["due_cards"]))
+	} else {
+		content.WriteString("• No cards in this deck\n")
+	}
+
+	if len(v.currentDeck.SubDecks) > 0 {
+		content.WriteString(fmt.Sprintf("• Subdecks: %d\n", len(v.currentDeck.SubDecks)))
+	}
+
+	content.WriteString("\n")
+
+	// Available decks list with fixed column width layout
+	content.WriteString(styles.Highlight.Render("Select a deck:") + "\n\n")
+
+	if len(v.visibleDecks) == 0 {
+		content.WriteString(styles.DimmedText.Render("No decks found. Press 'C' to create a new deck."))
+		content.WriteString("\n")
+	} else {
+		// Use a table-like layout with fixed columns
+		format := "%-2s %-14s %-18s\n"
+
+		// Render parent deck as "Back" option if not at root
+		startIdx := 0
+		if v.currentDeck != v.store.RootDeck && v.currentDeck.ParentDeck != nil && len(v.visibleDecks) > 0 {
+			isSelected := v.cursor == 0
+			cursor := " "
+			if isSelected {
+				cursor = ">"
+			}
+
+			if isSelected {
+				content.WriteString(fmt.Sprintf(format, cursor,
+					styles.Highlight.Render("← Back"), ""))
+			} else {
+				content.WriteString(fmt.Sprintf(format, cursor, "← Back", ""))
+			}
+			startIdx = 1
+		}
+
+		// Render subdeck list with fixed column positioning
+		for i := startIdx; i < len(v.visibleDecks); i++ {
+			d := v.visibleDecks[i]
+			deckStats := v.store.GetDeckStats(d)
+
+			isSelected := v.cursor == i
+			cursor := " "
+			if isSelected {
+				cursor = ">"
+			}
+
+			stats := fmt.Sprintf("(%d cards, %d due)",
+				deckStats["total_cards"],
+				deckStats["due_cards"])
+
+			if isSelected {
+				content.WriteString(fmt.Sprintf(format, cursor,
+					styles.Highlight.Render(d.Name),
+					styles.Highlight.Render(stats)))
+			} else {
+				content.WriteString(fmt.Sprintf(format, cursor, d.Name, stats))
+			}
+		}
+	}
+
+	// Add some empty lines for visual spacing (just one line to avoid excess space)
+	content.WriteString("\n")
+
+	// Single line help text with no wrapping
+	content.WriteString(styles.Subtle.Render("Navigate with arrow keys, press Enter to select a deck, Esc to go back"))
+
+	v.viewport.SetContent(content.String())
+}

--- a/internal/ui/views/views.go
+++ b/internal/ui/views/views.go
@@ -12,9 +12,9 @@ import (
 type ViewState int
 
 const (
-	ViewReview ViewState = iota
-	ViewDeckList
-	ViewDeckBrowser
+	ViewReview      ViewState = iota
+	ViewDeckList              // Deck list navigation view
+	ViewDeckBrowser           // Deck browser (current deck details)
 	ViewDeckStats
 	ViewCreateDeck
 	ViewRenameDeck


### PR DESCRIPTION
This PR adds a new deck navigation feature that allows users to browse through their deck hierarchy and select different decks for reviewing or managing cards. The implementation includes support for traditional arrow key navigation as well as vim and emacs-style key bindings.

## Features Added

- **New DeckListView Component**: A dedicated view for navigating the deck hierarchy
- **Multiple Navigation Methods**:
  - Arrow keys: ↑/↓ for movement, Enter to select
  - Vim keys: h (back), j (down), k (up), l (select)
  - Emacs keys: Ctrl+p (previous), Ctrl+n (next), Ctrl+b (back), Ctrl+f (forward)
- **Improved UI Layout**: Fixed-width column format with consistent cursor positioning
- **Visual Feedback**: Highlighted selection with clear indication of current position
- **Navigation Aids**: Breadcrumb trail showing current location in deck hierarchy
- **Informative Display**: Shows total cards and due cards for each deck

## Technical Implementation

- Created a new `deck_list_view.go` file with the DeckListView component
- Fixed duplicate declarations between `deck_view.go` and `deck_browser_view.go`
- Updated existing UI components to connect with the new navigation view
- Applied consistent formatting and styling across the deck navigation UI
- Updated the README.md to document the new feature and key bindings

## Testing

Tested on Linux terminal with various deck structures. Verified that:
- Navigation works properly with all supported key bindings
- UI maintains consistent alignment regardless of deck selection
- Back navigation functions correctly through the deck hierarchy
- Breadcrumb trail accurately reflects the current position

## Screenshots

*[Include screenshots of the deck navigation view here if available]*

## Related Issues

Resolves issue #15: Implement Deck Organization through Directory Structure