### PR TITLE
ci: add comprehensive test coverage infrastructure

### DIFF
--- a/.github/workflows/go-coverage.yml
+++ b/.github/workflows/go-coverage.yml
@@ -1,0 +1,72 @@
+name: Go Coverage
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  coverage:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+        check-latest: true
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Go Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Run tests with coverage
+      run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+    - name: Convert coverage to lcov format
+      run: |
+        go install github.com/jandelgado/gcov2lcov@latest
+        gcov2lcov -infile=coverage.out -outfile=coverage.lcov
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage.lcov
+        flags: unittests
+        fail_ci_if_error: false
+
+    - name: Generate Coverage Report
+      run: go tool cover -func=coverage.out > coverage.txt
+
+    - name: Check Coverage Threshold
+      run: |
+        COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+        echo "Total coverage: $COVERAGE%"
+        if (( $(echo "$COVERAGE < 70" | bc -l) )); then
+          echo "Coverage is below threshold of 70%"
+          exit 0  # Don't fail the build yet, just report
+        else
+          echo "Coverage meets threshold of 70%"
+        fi
+
+    - name: Upload coverage report artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: |
+          coverage.out
+          coverage.txt
+          coverage.lcov

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,8 +33,18 @@ jobs:
     - name: Get dependencies
       run: go mod download
 
-    - name: Run tests
-      run: go test -v ./...
+    # Add to .github/workflows/go.yml
+    - name: Run tests with coverage
+      run: |
+        go test -short -v -coverprofile=coverage.out ./...
+        go tool cover -func=coverage.out
+
+        # Optional: Add coverage threshold check
+        COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+        if (( $(echo "$COVERAGE < 70" | bc -l) )); then
+          echo "Test coverage is below 70%: $COVERAGE%"
+          exit 1
+        fi
 
   lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 # Filename: Makefile
 # Version: 0.0.0
 
+.PHONY: clean
+clean:
+	rm -f GoCard
+	go clean
+
 .PHONY: pre-commit-setup
 pre-commit-setup:
 	@echo "Setting up pre-commit hooks..."
@@ -16,15 +21,43 @@ GoCard:
 format:
 	go fmt ./...
 
-.PHONY: test
-test:
-	go test ./...
-
 .PHONY: lint
 lint:
 	golangci-lint run
 
-.PHONY: clean
-clean:
-	rm -f GoCard
-	go clean
+.PHONY: test
+test:
+	go test ./...
+
+.PHONY: test-cover
+test-cover:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
+.PHONY: test-cover-html
+test-cover-html: test-cover
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "Coverage report generated: coverage.html"
+	@echo "Open with: xdg-open coverage.html"
+
+.PHONY: test-cover-verbose
+test-cover-verbose:
+	go test -v -covermode=count -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
+
+.PHONY: test-cover-report
+test-cover-report:
+	@./scripts/generate_coverage_report.sh
+
+# Target for checking if coverage meets threshold (e.g., 70%)
+.PHONY: test-cover-check
+test-cover-check:
+	@go test -coverprofile=coverage.out ./...
+	@coverage=$$(go tool cover -func=coverage.out | grep total | awk '{print $$3}' | tr -d '%'); \
+	echo "Total coverage: $$coverage%"; \
+	if [ $$(echo "$$coverage < 70" | bc -l) -eq 1 ]; then \
+		echo "Coverage is below threshold of 70%"; \
+		exit 1; \
+	else \
+		echo "Coverage meets threshold of 70%"; \
+	fi

--- a/scripts/generate_coverage_report.sh
+++ b/scripts/generate_coverage_report.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# scripts/generate_coverage_report.sh
+
+# Create directory for reports
+mkdir -p coverage/reports
+
+# Run tests with coverage
+go test -coverprofile=coverage/coverage.out ./...
+
+# Generate summary
+go tool cover -func=coverage/coverage.out > coverage/summary.txt
+total=$(grep "total:" coverage/summary.txt | awk '{print $3}')
+echo "Total coverage: $total"
+
+# Generate HTML report
+go tool cover -html=coverage/coverage.out -o coverage/report.html
+
+# Generate per-package coverage information
+echo "Package coverage:" > coverage/packages.txt
+go tool cover -func=coverage/coverage.out | grep -v "total:" >> coverage/packages.txt
+
+# Identify packages with low coverage (below 50%)
+echo "Low coverage packages:" > coverage/low_coverage.txt
+go tool cover -func=coverage/coverage.out | awk '$3 < "50.0%" && $1 !~ /total/ {print $1 ": " $3}' >> coverage/low_coverage.txt
+
+# Identify files with no tests
+echo "Files without tests:" > coverage/no_tests.txt
+go list -f '{{.Dir}}' ./... | while read -r pkg; do
+  go list -f '{{range .GoFiles}}{{$.Dir}}/{{.}}{{"\n"}}{{end}}' "$pkg" | while read -r file; do
+    if ! grep -q "$(basename "$file" .go)" coverage/coverage.out; then
+      echo "$file" >> coverage/no_tests.txt
+    fi
+  done
+done
+
+echo "Coverage reports generated in the coverage directory"

--- a/scripts/package_coverage.sh
+++ b/scripts/package_coverage.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# scripts/package_coverage.sh
+
+# Create output directory
+mkdir -p coverage_analysis
+
+# Get list of all packages
+packages=$(go list ./...)
+
+# Run tests for each package individually and generate report
+echo "Package Coverage:"
+echo "================="
+echo "Package | Coverage | Files | Lines of Code | Covered Lines"
+echo "--------|----------|-------|--------------|-------------"
+
+for pkg in $packages; do
+    # Skip test packages
+    if [[ $pkg == *"_test" ]]; then
+        continue
+    fi
+
+    echo "Testing $pkg..."
+
+    # Run tests for this package only
+    go test -coverprofile=coverage_analysis/temp.out $pkg >/dev/null 2>&1
+
+    if [ $? -eq 0 ]; then
+        # Get coverage percentage
+        coverage=$(go tool cover -func=coverage_analysis/temp.out | grep total | awk '{print $3}')
+
+        # Count files
+        files=$(go list -f '{{len .GoFiles}}' $pkg)
+
+        # Get lines of code (approximate)
+        lines=$(find $(go list -f '{{.Dir}}' $pkg) -name "*.go" -not -path "*_test.go" | xargs wc -l 2>/dev/null | tail -n 1 | awk '{print $1}')
+
+        # Calculate covered lines (approximate)
+        if [[ $coverage == *"%" ]]; then
+            coverage_num=${coverage//%/}
+            covered_lines=$(echo "$lines * $coverage_num / 100" | bc)
+        else
+            covered_lines="N/A"
+        fi
+
+        echo "$pkg | $coverage | $files | $lines | $covered_lines" | tee -a coverage_analysis/package_report.txt
+    else
+        echo "$pkg | 0.0% | N/A | N/A | 0" | tee -a coverage_analysis/package_report.txt
+    fi
+done
+
+# Sort packages by coverage (lowest first)
+echo -e "\nRanked by Coverage (lowest first):"
+echo "============================="
+tail -n +3 coverage_analysis/package_report.txt | sort -t'|' -k2 -n | head -10
+
+# Clean up temporary files
+rm coverage_analysis/temp.out
+
+echo -e "\nFull report saved to coverage_analysis/package_report.txt"

--- a/scripts/visual_coverage_report.sh
+++ b/scripts/visual_coverage_report.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# scripts/visual_coverage_report.sh
+
+# Ensure go-cover-treemap is installed
+if ! command -v go-cover-treemap &> /dev/null; then
+    echo "Installing go-cover-treemap..."
+    go install github.com/nikolaydubina/go-cover-treemap@latest
+fi
+
+# Ensure gocovsh is installed
+if ! command -v gocovsh &> /dev/null; then
+    echo "Installing gocovsh..."
+    go install github.com/orlangure/gocovsh@latest
+fi
+
+# Run tests with coverage
+echo "Running tests with coverage..."
+go test -coverprofile=coverage.out ./...
+
+# Generate HTML report
+echo "Generating standard HTML report..."
+go tool cover -html=coverage.out -o coverage.html
+
+# Generate treemap visualization
+echo "Generating treemap visualization..."
+go-cover-treemap -coverprofile coverage.out > coverage_treemap.svg
+
+# Generate coverage heat map directory
+mkdir -p coverage_report
+echo "Generating coverage heat map..."
+gocovsh covdata --profile coverage.out --html ./coverage_report
+
+echo "Coverage reports generated:"
+echo "1. Standard HTML: coverage.html"
+echo "2. Treemap visualization: coverage_treemap.svg"
+echo "3. Interactive heatmap: ./coverage_report/index.html"


### PR DESCRIPTION
Add complete test coverage analysis infrastructure to the project:

- Add GitHub Actions workflow for coverage reporting
- Modify existing CI workflow to work with coverage analysis
- Update Makefile with coverage analysis targets
- Add three specialized coverage scripts:
  - generate_coverage_report.sh: Creates detailed text reports
  - package_coverage.sh: Analyzes coverage by package
  - visual_coverage_report.sh: Generates visual coverage representations

This infrastructure will help identify areas needing more tests and track coverage improvements over time. The setup includes both local tooling and CI integration for continuous coverage monitoring.