### PR TITLE
Replace single-key shortcuts with modifier combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Organize your cards however you want! The directory structure becomes the deck s
 
 GoCard lets you browse your deck hierarchy with an intuitive navigation interface:
 
-1. Press `c` from any screen to enter the deck navigation view
-2. Navigate between decks using arrow keys or vim/emacs keybindings
+1. Press `Ctrl+o` from any screen to enter the deck navigation view
+2. Navigate between decks using arrow keys or vim keybindings
 3. Press `Enter` to select a deck or `Esc` to go back
 
 The deck navigation shows useful information for each deck:
@@ -242,9 +242,9 @@ The deck navigation shows useful information for each deck:
 
 Keyboard shortcuts make navigation efficient:
 
-- Arrow keys, `j`/`k` (vim), or `Ctrl+n`/`Ctrl+p` (emacs) to move up/down
-- `Enter`, `l` (vim), or `Ctrl+f` (emacs) to select a deck
-- `Esc`, `h` (vim), or `Ctrl+b` (emacs) to go back
+- Arrow keys, `j`/`k` to move up/down
+- `Enter` to select a deck
+- `Esc` to go back
 
 ## Spaced Repetition System
 
@@ -275,26 +275,23 @@ GoCard provides a clean, minimalist terminal interface optimized for focused lea
 |----------------------|----------------------------|
 | `Space`              | Show answer                |
 | `0-5`                | Rate card difficulty       |
-| `c`                  | Change deck                |
-| `C`                  | Create new deck            |
-| `n`                  | Create new card            |
-| `s`                  | Search cards               |
-| `?`                  | Toggle help                |
-| `q`                  | Quit                       |
+| `Ctrl+o`             | Change deck                |
+| `Ctrl+Shift+n`       | Create new deck            |
+| `Ctrl+n`             | Create new card            |
+| `Ctrl+f`             | Search cards               |
+| `Ctrl+h` or `F1`     | Toggle help                |
+| `Ctrl+q`             | Quit                       |
 | **Navigation Keys**  |                            |
-| `↑/k/Ctrl+p`         | Move up in lists           |
-| `↓/j/Ctrl+n`         | Move down in lists         |
-| `Enter/l/Ctrl+f`     | Select/move forward        |
-| `Esc/h/Ctrl+b`       | Go back                    |
-
-Additional shortcuts planned for future versions:
-
-- `e` - Edit current card
-- `d` - Delete current card
-- `t` - Add/edit tags
-- `r` - Rename deck
-- `D` - Delete deck
-- `m` - Move cards between decks
+| `↑/k`                | Move up in lists           |
+| `↓/j`                | Move down in lists         |
+| `Enter`              | Select/move forward        |
+| `Esc`                | Go back                    |
+| `Ctrl+e`             | Edit current card          |
+| `Ctrl+d`             | Delete current card        |
+| `Ctrl+t`             | Add/edit tags              |
+| `Ctrl+r`             | Rename deck                |
+| `Ctrl+Shift+d`       | Delete deck                |
+| `Ctrl+m`             | Move cards between decks   |
 
 ## Review Process
 

--- a/internal/ui/input/keymap.go
+++ b/internal/ui/input/keymap.go
@@ -44,7 +44,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	}
 }
 
-// NewKeyMap creates the default keybindings
+// NewKeyMap creates the default keybindings with editor-friendly modifier keys
 func NewKeyMap() KeyMap {
 	return KeyMap{
 		ShowAnswer: key.NewBinding(
@@ -76,55 +76,55 @@ func NewKeyMap() KeyMap {
 			key.WithHelp("5", "rate: very easy"),
 		),
 		Edit: key.NewBinding(
-			key.WithKeys("e"),
-			key.WithHelp("e", "edit card"),
+			key.WithKeys("ctrl+e"),
+			key.WithHelp("ctrl+e", "edit card"),
 		),
 		New: key.NewBinding(
-			key.WithKeys("n"),
-			key.WithHelp("n", "new card"),
+			key.WithKeys("ctrl+n"),
+			key.WithHelp("ctrl+n", "new card"),
 		),
 		Delete: key.NewBinding(
-			key.WithKeys("d"),
-			key.WithHelp("d", "delete card"),
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "delete card"),
 		),
 		Tags: key.NewBinding(
-			key.WithKeys("t"),
-			key.WithHelp("t", "edit tags"),
+			key.WithKeys("ctrl+t"),
+			key.WithHelp("ctrl+t", "edit tags"),
 		),
 		Search: key.NewBinding(
-			key.WithKeys("s"),
-			key.WithHelp("s", "search"),
+			key.WithKeys("ctrl+f"),
+			key.WithHelp("ctrl+f", "search"),
 		),
 		ChangeDeck: key.NewBinding(
-			key.WithKeys("c"),
-			key.WithHelp("c", "change deck"),
+			key.WithKeys("ctrl+o"),
+			key.WithHelp("ctrl+o", "change deck"),
 		),
 		CreateDeck: key.NewBinding(
-			key.WithKeys("C"),
-			key.WithHelp("C", "create deck"),
+			key.WithKeys("ctrl+shift+n"),
+			key.WithHelp("ctrl+shift+n", "create deck"),
 		),
 		RenameDeck: key.NewBinding(
-			key.WithKeys("r"),
-			key.WithHelp("r", "rename deck"),
+			key.WithKeys("ctrl+r"),
+			key.WithHelp("ctrl+r", "rename deck"),
 		),
 		DeleteDeck: key.NewBinding(
-			key.WithKeys("D"),
-			key.WithHelp("D", "delete deck"),
+			key.WithKeys("ctrl+shift+d"),
+			key.WithHelp("ctrl+shift+d", "delete deck"),
 		),
 		MoveToDeck: key.NewBinding(
-			key.WithKeys("m"),
-			key.WithHelp("m", "move to deck"),
+			key.WithKeys("ctrl+m"),
+			key.WithHelp("ctrl+m", "move to deck"),
 		),
 		Quit: key.NewBinding(
-			key.WithKeys("q", "ctrl+c"),
-			key.WithHelp("q", "quit"),
+			key.WithKeys("ctrl+q"),
+			key.WithHelp("ctrl+q", "quit"),
 		),
 		Help: key.NewBinding(
-			key.WithKeys("?"),
-			key.WithHelp("?", "toggle help"),
+			key.WithKeys("ctrl+h", "f1"),
+			key.WithHelp("ctrl+h/f1", "toggle help"),
 		),
 		Back: key.NewBinding(
-			key.WithKeys("esc", "backspace"),
+			key.WithKeys("esc"),
 			key.WithHelp("esc", "go back"),
 		),
 	}

--- a/internal/ui/views/deck_browser_view.go
+++ b/internal/ui/views/deck_browser_view.go
@@ -123,7 +123,7 @@ func (v *DeckBrowserView) Render(width, height int) string {
 	sb.WriteString("\n")
 
 	// Render footer
-	footerText := "Press space to review, c to change deck, n for new card, ? for help"
+	footerText := "Press space to review, ctrl+o to change deck, ctrl+n for new card, ctrl+h for help"
 	sb.WriteString(v.renderer.FooterStyle(footerText))
 
 	return sb.String()

--- a/internal/ui/views/deck_list_view.go
+++ b/internal/ui/views/deck_list_view.go
@@ -243,7 +243,7 @@ func (v *DeckListView) Render(width, height int) string {
 	sb.WriteString("\n")
 
 	// Render footer - now with vim/emacs keys
-	footerText := "↑/j/k: Navigate • Enter/l: Select • Esc/h: Back • c: View Deck • ?: Help"
+	footerText := "↑/j/k: Navigate • Enter: Select • Esc: Back • ctrl+o: View Deck • ctrl+h: Help"
 	sb.WriteString(v.renderer.FooterStyle(footerText))
 
 	return sb.String()

--- a/internal/ui/views/review_view.go
+++ b/internal/ui/views/review_view.go
@@ -147,11 +147,11 @@ func (v *ReviewView) Render(width, height int) string {
 	// Render footer
 	var footerText string
 	if v.reviewState == StateShowingQuestion {
-		footerText = "Press space to show answer, ? for help"
+		footerText = "Press space to show answer, ctrl+h for help"
 	} else if v.reviewState == StateShowingAnswer {
-		footerText = "Rate 0-5, ? for help"
+		footerText = "Rate 0-5, ctrl+h for help"
 	} else {
-		footerText = "Press esc to return to deck browser, q to quit, ? for help"
+		footerText = "Press esc to return to deck browser, ctrl+q to quit, ctrl+h for help"
 	}
 	sb.WriteString(v.renderer.FooterStyle(footerText))
 


### PR DESCRIPTION
# Replace single-key shortcuts with modifier combinations

## Description

This PR replaces all single-key shortcuts with modifier key combinations (ctrl+key) to prepare for implementing the editing interface (Issue #5). This change prevents potential conflicts between text entry and application commands when we implement the card editing interface.

## Changes

- Updated `keymap.go` with new modifier key combinations:
  - `e` → `ctrl+e` for edit
  - `n` → `ctrl+n` for new card
  - `c` → `ctrl+o` for change deck
  - `C` → `ctrl+shift+n` for create deck
  - And other similar changes
- Updated footer text in all views to reflect the new key combinations
- Updated README.md with comprehensive keyboard shortcut documentation
- Simplified navigation instructions by removing redundant key alternatives

## Motivation

When implementing the editing interface (Issue #5), having single-key shortcuts would conflict with normal text entry. By moving to modifier key combinations now, we can avoid this conflict and ensure a smooth implementation of the editing functionality.

## Related Issues

Resolves part of Issue #5: Card Creation and Editing Interface

## Testing Instructions

- Clone this branch and build the application
- Verify all keyboard shortcuts work as expected with their new combinations
- Check the README.md to ensure the documentation accurately reflects the changes