### PR TITLE
Implement Card Creation and Editing Interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/alecthomas/chroma/v2 v2.15.0 h1:LxXTQHFoYrstG2nnV9y2X5O94sOBzf0CIUpST
 github.com/alecthomas/chroma/v2 v2.15.0/go.mod h1:gUhVLrPDXPtp/f+L1jo9xepo9gL4eLwRuGAunSZMkio=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=

--- a/internal/ui/input/keymap.go
+++ b/internal/ui/input/keymap.go
@@ -1,3 +1,5 @@
+// File: internal/ui/input/keymap.go
+
 // Package input handles user input and key bindings for the UI.
 package input
 
@@ -76,16 +78,16 @@ func NewKeyMap() KeyMap {
 			key.WithHelp("5", "rate: very easy"),
 		),
 		Edit: key.NewBinding(
-			key.WithKeys("ctrl+e"),
-			key.WithHelp("ctrl+e", "edit card"),
+			key.WithKeys("ctrl+e", "f4"),
+			key.WithHelp("ctrl+e/f4", "edit card"),
 		),
 		New: key.NewBinding(
 			key.WithKeys("ctrl+n"),
 			key.WithHelp("ctrl+n", "new card"),
 		),
 		Delete: key.NewBinding(
-			key.WithKeys("ctrl+d"),
-			key.WithHelp("ctrl+d", "delete card"),
+			key.WithKeys("ctrl+x d"),
+			key.WithHelp("ctrl+x d", "delete card"),
 		),
 		Tags: key.NewBinding(
 			key.WithKeys("ctrl+t"),
@@ -100,16 +102,16 @@ func NewKeyMap() KeyMap {
 			key.WithHelp("ctrl+o", "change deck"),
 		),
 		CreateDeck: key.NewBinding(
-			key.WithKeys("ctrl+shift+n"),
-			key.WithHelp("ctrl+shift+n", "create deck"),
+			key.WithKeys("ctrl+alt+n"),
+			key.WithHelp("ctrl+alt+n", "create deck"),
 		),
 		RenameDeck: key.NewBinding(
-			key.WithKeys("ctrl+r"),
-			key.WithHelp("ctrl+r", "rename deck"),
+			key.WithKeys("f2"),
+			key.WithHelp("f2", "rename deck"),
 		),
 		DeleteDeck: key.NewBinding(
-			key.WithKeys("ctrl+shift+d"),
-			key.WithHelp("ctrl+shift+d", "delete deck"),
+			key.WithKeys("ctrl+alt+d"),
+			key.WithHelp("ctrl+alt+d", "delete deck"),
 		),
 		MoveToDeck: key.NewBinding(
 			key.WithKeys("ctrl+m"),

--- a/internal/ui/views/card_edit_view.go
+++ b/internal/ui/views/card_edit_view.go
@@ -1,4 +1,4 @@
-// File: internal/ui/views/edit_card_view.go
+// File: internal/ui/views/card_edit_view.go
 package views
 
 import (
@@ -118,13 +118,14 @@ func (v *CardEditView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd) {
 					v.previousField()
 					return v, nil
 				}
+			// For textareas, use alt+arrows instead of ctrl+tab
 			case FieldQuestion, FieldAnswer:
-				// Let textarea handle tab/shift+tab internally for indentation
-				// Only intercept when combined with a modifier key
-				if msg.String() == "ctrl+tab" {
+				// Let textarea handle tab internally for indentation
+				// Use alt+up/down for field navigation
+				if msg.String() == "alt+down" {
 					v.nextField()
 					return v, nil
-				} else if msg.String() == "ctrl+shift+tab" {
+				} else if msg.String() == "alt+up" {
 					v.previousField()
 					return v, nil
 				}
@@ -294,7 +295,7 @@ func (v *CardEditView) Render(width, height int) string {
 	// Render footer with shortcuts
 	var footerText string
 	if v.activeField == FieldQuestion || v.activeField == FieldAnswer {
-		footerText = "Ctrl+Tab: Next Field • Ctrl+Shift+Tab: Previous Field • Ctrl+p: Preview • Ctrl+s: Save • Esc: Cancel"
+		footerText = "Alt+Down: Next Field • Alt+Up: Previous Field • Ctrl+p: Preview • Ctrl+s: Save • Esc: Cancel"
 	} else {
 		footerText = "Tab: Next Field • Shift+Tab: Previous Field • Ctrl+p: Preview • Ctrl+s: Save • Esc: Cancel"
 	}

--- a/internal/ui/views/deck_browser_view.go
+++ b/internal/ui/views/deck_browser_view.go
@@ -129,8 +129,8 @@ func (v *DeckBrowserView) Render(width, height int) string {
 	sb.WriteString(v.viewport.View())
 	sb.WriteString("\n")
 
-	// Render footer
-	footerText := "Press space to review, ctrl+o to change deck, ctrl+n for new card, ctrl+h for help"
+	// Render footer with updated key bindings
+	footerText := "Space: review • ctrl+o: change deck • ctrl+n: new card • ctrl+alt+n: new deck • ctrl+e/f4: edit • ctrl+h: help"
 	sb.WriteString(v.renderer.FooterStyle(footerText))
 
 	return sb.String()
@@ -171,10 +171,13 @@ func (v *DeckBrowserView) updateDeckBrowser() {
 	if stats["due_cards"].(int) > 0 {
 		content.WriteString("- Press space to start review session\n")
 	}
-	content.WriteString("- Press 'c' to change deck\n")
-	content.WriteString("- Press 'C' to create a new deck\n")
-	content.WriteString("- Press 'n' to create a new card\n")
-	content.WriteString("- Press 's' to search cards\n")
+	content.WriteString("- Press ctrl+o to change deck\n")
+	content.WriteString("- Press ctrl+alt+n to create a new deck\n")
+	content.WriteString("- Press ctrl+n to create a new card\n")
+	content.WriteString("- Press ctrl+f to search cards\n")
+	content.WriteString("- Press ctrl+e/f4 to edit card\n")
+	content.WriteString("- Press ctrl+x d to delete card\n")
+	content.WriteString("- Press f2 to rename deck\n")
 
 	// Add cards list if there are cards in this deck
 	if len(v.currentDeck.Cards) > 0 {

--- a/internal/ui/views/deck_browser_view.go
+++ b/internal/ui/views/deck_browser_view.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/DavidMiserak/GoCard/internal/card"
 	"github.com/DavidMiserak/GoCard/internal/deck"
 	"github.com/DavidMiserak/GoCard/internal/storage"
 	"github.com/DavidMiserak/GoCard/internal/ui/input"
@@ -83,8 +84,14 @@ func (v *DeckBrowserView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd)
 			return deckListView, deckListView.Init()
 
 		case input.KeyMatches(msg, keys.New):
-			// This would launch the create card view
-			v.SetError("Create card view not yet implemented in refactored version")
+			// Launch card creation view
+			newCard := card.NewCard("", "", "", []string{})
+			editView, err := NewCardEditView(v.store, newCard, true, v.currentDeck.PathFromRoot(), v.width, v.height)
+			if err != nil {
+				v.SetError(fmt.Sprintf("Error creating card: %v", err))
+				return v, nil
+			}
+			return editView, editView.Init()
 
 		case input.KeyMatches(msg, keys.Search):
 			// This would launch the search view

--- a/internal/ui/views/edit_card_view.go
+++ b/internal/ui/views/edit_card_view.go
@@ -1,0 +1,455 @@
+// File: internal/ui/views/edit_card_view.go
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/DavidMiserak/GoCard/internal/card"
+	"github.com/DavidMiserak/GoCard/internal/storage"
+	"github.com/DavidMiserak/GoCard/internal/ui/input"
+	"github.com/DavidMiserak/GoCard/internal/ui/render"
+)
+
+// EditorField represents which field is currently being edited
+type EditorField int
+
+const (
+	FieldTitle EditorField = iota
+	FieldTags
+	FieldQuestion
+	FieldAnswer
+	FieldNone
+)
+
+// EditorMode represents the current mode of the editor
+type EditorMode int
+
+const (
+	ModeEdit EditorMode = iota
+	ModePreview
+)
+
+// CardEditView handles the card editing interface
+type CardEditView struct {
+	BaseView
+	store        *storage.CardStore
+	renderer     *render.Renderer
+	card         *card.Card
+	originalDeck string
+	isNewCard    bool
+
+	mode        EditorMode
+	activeField EditorField
+
+	titleInput    textinput.Model
+	tagsInput     textinput.Model
+	questionInput textarea.Model
+	answerInput   textarea.Model
+
+	previewContent string
+	showHelp       bool
+	errorMsg       string
+}
+
+// NewCardEditView creates a new card editing view
+func NewCardEditView(store *storage.CardStore, cardToEdit *card.Card, isNew bool, deckPath string, width, height int) (*CardEditView, error) {
+	baseView := NewBaseView(ViewEditCard, width, height)
+
+	renderer, err := render.NewRenderer(width)
+	if err != nil {
+		return nil, err
+	}
+
+	view := &CardEditView{
+		BaseView:     baseView,
+		store:        store,
+		renderer:     renderer,
+		card:         cardToEdit,
+		originalDeck: deckPath,
+		isNewCard:    isNew,
+		mode:         ModeEdit,
+		activeField:  FieldTitle,
+	}
+
+	// Initialize text inputs
+	view.initInputs()
+
+	// If it's a new card, provide a template
+	if isNew {
+		view.questionInput.SetValue("Enter your question here...")
+		view.answerInput.SetValue("Enter your answer here...")
+	}
+
+	return view, nil
+}
+
+// Init implements View.Init
+func (v *CardEditView) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+// Update implements View.Update
+func (v *CardEditView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// Handle global keys first
+		if v.mode == ModeEdit && v.activeField != FieldNone {
+			switch v.activeField {
+			case FieldTitle:
+				if msg.String() == "tab" {
+					v.nextField()
+					return v, nil
+				} else if msg.String() == "shift+tab" {
+					v.previousField()
+					return v, nil
+				}
+			case FieldTags:
+				if msg.String() == "tab" {
+					v.nextField()
+					return v, nil
+				} else if msg.String() == "shift+tab" {
+					v.previousField()
+					return v, nil
+				}
+			case FieldQuestion, FieldAnswer:
+				// Let textarea handle tab/shift+tab internally for indentation
+				// Only intercept when combined with a modifier key
+				if msg.String() == "ctrl+tab" {
+					v.nextField()
+					return v, nil
+				} else if msg.String() == "ctrl+shift+tab" {
+					v.previousField()
+					return v, nil
+				}
+			}
+		}
+
+		// Global key handlers
+		switch {
+		case input.KeyMatches(msg, keys.Quit):
+			return v, tea.Quit
+
+		case input.KeyMatches(msg, keys.Back):
+			// Return to previous view without saving
+			if v.isNewCard {
+				// Return to deck browser for new cards
+				deckView, err := NewDeckBrowserView(v.store, v.originalDeck, v.width, v.height)
+				if err != nil {
+					v.errorMsg = fmt.Sprintf("Error returning to deck browser: %v", err)
+					return v, nil
+				}
+				return deckView, deckView.Init()
+			} else {
+				// Return to review view for existing cards
+				reviewView, err := NewReviewView(v.store, v.originalDeck, v.width, v.height)
+				if err != nil {
+					v.errorMsg = fmt.Sprintf("Error returning to review: %v", err)
+					return v, nil
+				}
+				return reviewView, reviewView.Init()
+			}
+
+		case msg.String() == "ctrl+p":
+			// Toggle preview mode
+			if v.mode == ModeEdit {
+				v.mode = ModePreview
+				v.updatePreview()
+			} else {
+				v.mode = ModeEdit
+			}
+			return v, nil
+
+		case msg.String() == "ctrl+s":
+			// Save card
+			err := v.saveCard()
+			if err != nil {
+				v.errorMsg = fmt.Sprintf("Error saving card: %v", err)
+				return v, nil
+			}
+
+			// Return to appropriate view
+			if v.isNewCard {
+				deckView, err := NewDeckBrowserView(v.store, v.originalDeck, v.width, v.height)
+				if err != nil {
+					v.errorMsg = fmt.Sprintf("Error returning to deck browser: %v", err)
+					return v, nil
+				}
+				return deckView, deckView.Init()
+			} else {
+				reviewView, err := NewReviewView(v.store, v.originalDeck, v.width, v.height)
+				if err != nil {
+					v.errorMsg = fmt.Sprintf("Error returning to review: %v", err)
+					return v, nil
+				}
+				return reviewView, reviewView.Init()
+			}
+		}
+
+	case tea.WindowSizeMsg:
+		v.SetDimensions(msg.Width, msg.Height)
+		if err := v.renderer.UpdateWidth(msg.Width); err != nil {
+			v.errorMsg = fmt.Sprintf("Error updating renderer: %v", err)
+		}
+
+		// Update textarea widths
+		v.questionInput.SetWidth(msg.Width - 4)
+		v.answerInput.SetWidth(msg.Width - 4)
+	}
+
+	// Handle input for active field
+	switch v.activeField {
+	case FieldTitle:
+		newTitleModel, cmd := v.titleInput.Update(msg)
+		v.titleInput = newTitleModel
+		cmds = append(cmds, cmd)
+
+	case FieldTags:
+		newTagsModel, cmd := v.tagsInput.Update(msg)
+		v.tagsInput = newTagsModel
+		cmds = append(cmds, cmd)
+
+	case FieldQuestion:
+		newQuestionModel, cmd := v.questionInput.Update(msg)
+		v.questionInput = newQuestionModel
+		cmds = append(cmds, cmd)
+
+	case FieldAnswer:
+		newAnswerModel, cmd := v.answerInput.Update(msg)
+		v.answerInput = newAnswerModel
+		cmds = append(cmds, cmd)
+	}
+
+	return v, tea.Batch(cmds...)
+}
+
+// Render implements View.Render
+func (v *CardEditView) Render(width, height int) string {
+	var sb strings.Builder
+
+	// Render header
+	headerText := "GoCard - "
+	if v.isNewCard {
+		headerText += "Create New Card"
+	} else {
+		headerText += "Edit Card: " + v.card.Title
+	}
+	sb.WriteString(v.renderer.HeaderStyle(headerText))
+	sb.WriteString("\n")
+
+	// Render error if present
+	if v.errorMsg != "" {
+		sb.WriteString(v.renderer.ErrorStyle(v.errorMsg))
+		sb.WriteString("\n")
+	}
+
+	// Main content
+	if v.mode == ModeEdit {
+		// Render edit interface
+		sb.WriteString("\n")
+
+		// Title field
+		if v.activeField == FieldTitle {
+			sb.WriteString(v.renderer.GetStyles().Highlight.Render("Title:") + "\n")
+		} else {
+			sb.WriteString("Title:\n")
+		}
+		sb.WriteString(v.titleInput.View() + "\n\n")
+
+		// Tags field
+		if v.activeField == FieldTags {
+			sb.WriteString(v.renderer.GetStyles().Highlight.Render("Tags (comma separated):") + "\n")
+		} else {
+			sb.WriteString("Tags (comma separated):\n")
+		}
+		sb.WriteString(v.tagsInput.View() + "\n\n")
+
+		// Question field
+		if v.activeField == FieldQuestion {
+			sb.WriteString(v.renderer.GetStyles().Highlight.Render("Question:") + "\n")
+		} else {
+			sb.WriteString("Question:\n")
+		}
+		sb.WriteString(v.questionInput.View() + "\n\n")
+
+		// Answer field
+		if v.activeField == FieldAnswer {
+			sb.WriteString(v.renderer.GetStyles().Highlight.Render("Answer:") + "\n")
+		} else {
+			sb.WriteString("Answer:\n")
+		}
+		sb.WriteString(v.answerInput.View() + "\n")
+
+	} else {
+		// Render preview
+		sb.WriteString(v.previewContent)
+	}
+
+	// Render footer with shortcuts
+	var footerText string
+	if v.activeField == FieldQuestion || v.activeField == FieldAnswer {
+		footerText = "Ctrl+Tab: Next Field • Ctrl+Shift+Tab: Previous Field • Ctrl+p: Preview • Ctrl+s: Save • Esc: Cancel"
+	} else {
+		footerText = "Tab: Next Field • Shift+Tab: Previous Field • Ctrl+p: Preview • Ctrl+s: Save • Esc: Cancel"
+	}
+	sb.WriteString("\n" + v.renderer.FooterStyle(footerText))
+
+	return sb.String()
+}
+
+// initInputs initializes all text inputs
+func (v *CardEditView) initInputs() {
+	// Initialize title input
+	v.titleInput = textinput.New()
+	v.titleInput.Placeholder = "Card Title"
+	v.titleInput.Focus()
+	v.titleInput.CharLimit = 100
+	v.titleInput.Width = v.width - 4
+
+	if v.card.Title != "" {
+		v.titleInput.SetValue(v.card.Title)
+	}
+
+	// Initialize tags input
+	v.tagsInput = textinput.New()
+	v.tagsInput.Placeholder = "tag1, tag2, tag3"
+	v.tagsInput.CharLimit = 200
+	v.tagsInput.Width = v.width - 4
+
+	if len(v.card.Tags) > 0 {
+		v.tagsInput.SetValue(strings.Join(v.card.Tags, ", "))
+	}
+
+	// Initialize question input - now using textarea
+	v.questionInput = textarea.New()
+	v.questionInput.Placeholder = "Enter question..."
+	v.questionInput.SetWidth(v.width - 4)
+	v.questionInput.SetHeight(5) // Show 5 lines
+
+	if v.card.Question != "" {
+		v.questionInput.SetValue(v.card.Question)
+	}
+
+	// Initialize answer input - now using textarea
+	v.answerInput = textarea.New()
+	v.answerInput.Placeholder = "Enter answer..."
+	v.answerInput.SetWidth(v.width - 4)
+	v.answerInput.SetHeight(10) // Show 10 lines
+
+	if v.card.Answer != "" {
+		v.answerInput.SetValue(v.card.Answer)
+	}
+}
+
+// updatePreview generates markdown preview from inputs
+func (v *CardEditView) updatePreview() {
+	var content strings.Builder
+
+	content.WriteString("# " + v.titleInput.Value() + "\n\n")
+	content.WriteString("## Question\n\n")
+	content.WriteString(v.questionInput.Value() + "\n\n")
+	content.WriteString("## Answer\n\n")
+	content.WriteString(v.answerInput.Value())
+
+	rendered, err := v.store.RenderMarkdown(content.String())
+	if err != nil {
+		v.errorMsg = fmt.Sprintf("Error rendering preview: %v", err)
+		v.previewContent = content.String()
+	} else {
+		v.previewContent = rendered
+	}
+}
+
+// saveCard saves the card to storage
+func (v *CardEditView) saveCard() error {
+	// Update card from inputs
+	v.card.Title = v.titleInput.Value()
+	v.card.Question = v.questionInput.Value()
+	v.card.Answer = v.answerInput.Value()
+
+	// Parse tags
+	tagStr := v.tagsInput.Value()
+	tags := strings.Split(tagStr, ",")
+	cleanTags := []string{}
+
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag != "" {
+			cleanTags = append(cleanTags, tag)
+		}
+	}
+
+	v.card.Tags = cleanTags
+
+	// Save card
+	if v.isNewCard {
+		// For new cards, get the current deck
+		deckObj, err := v.store.GetDeckByRelativePath(v.originalDeck)
+		if err != nil {
+			return fmt.Errorf("failed to get deck: %w", err)
+		}
+
+		// Create new card in deck
+		_, err = v.store.CreateCardInDeck(
+			v.card.Title,
+			v.card.Question,
+			v.card.Answer,
+			v.card.Tags,
+			deckObj,
+		)
+		return err
+	} else {
+		// For existing cards, update
+		return v.store.SaveCard(v.card)
+	}
+}
+
+// nextField moves to the next input field
+func (v *CardEditView) nextField() {
+	switch v.activeField {
+	case FieldTitle:
+		v.activeField = FieldTags
+		v.titleInput.Blur()
+		v.tagsInput.Focus()
+	case FieldTags:
+		v.activeField = FieldQuestion
+		v.tagsInput.Blur()
+		v.questionInput.Focus()
+	case FieldQuestion:
+		v.activeField = FieldAnswer
+		v.questionInput.Blur()
+		v.answerInput.Focus()
+	case FieldAnswer:
+		v.activeField = FieldTitle
+		v.answerInput.Blur()
+		v.titleInput.Focus()
+	}
+}
+
+// previousField moves to the previous input field
+func (v *CardEditView) previousField() {
+	switch v.activeField {
+	case FieldTitle:
+		v.activeField = FieldAnswer
+		v.titleInput.Blur()
+		v.answerInput.Focus()
+	case FieldTags:
+		v.activeField = FieldTitle
+		v.tagsInput.Blur()
+		v.titleInput.Focus()
+	case FieldQuestion:
+		v.activeField = FieldTags
+		v.questionInput.Blur()
+		v.tagsInput.Focus()
+	case FieldAnswer:
+		v.activeField = FieldQuestion
+		v.answerInput.Blur()
+		v.questionInput.Focus()
+	}
+}

--- a/internal/ui/views/review_view.go
+++ b/internal/ui/views/review_view.go
@@ -81,6 +81,17 @@ func (v *ReviewView) Update(msg tea.Msg, keys input.KeyMap) (View, tea.Cmd) {
 				v.updateViewport()
 			}
 
+		case input.KeyMatches(msg, keys.Edit):
+			if v.currentCard != nil {
+				// Launch card edit view for current card
+				editView, err := NewCardEditView(v.store, v.currentCard, false, "", v.width, v.height)
+				if err != nil {
+					v.SetError(fmt.Sprintf("Error editing card: %v", err))
+					return v, nil
+				}
+				return editView, editView.Init()
+			}
+
 		case input.KeyMatches(msg, keys.Rate0),
 			input.KeyMatches(msg, keys.Rate1),
 			input.KeyMatches(msg, keys.Rate2),


### PR DESCRIPTION
This PR implements Issue #5: Card Creation and Editing Interface, adding the ability to create and edit cards directly within the GoCard application. Users can now create new cards with `Ctrl+n` or edit existing cards with `Ctrl+e/F4` without needing to exit the application or use an external text editor.

## Changes

- Added a new `CardEditView` component in `internal/ui/views/card_edit_view.go`
- Implemented multiline editing for question and answer fields using `textarea.Model`
- Added real-time Markdown preview functionality with `Ctrl+p`
- Integrated the editor with existing views (DeckBrowserView and ReviewView)
- Updated keyboard shortcuts throughout the application to avoid conflicts with terminal operations
- Updated the README.md with new documentation on the card editing feature

## Implementation Details

### New Card Editing View

The card editor provides a form-based interface with the following fields:
- Title: Simple text input for the card title
- Tags: Comma-separated list of tags
- Question: Multi-line text area with Markdown support
- Answer: Multi-line text area with Markdown support

The editor supports navigation between fields using Tab/Shift+Tab for simple fields and Alt+Up/Alt+Down for multiline text areas.

### Preview Mode

Users can toggle between editing and preview modes with `Ctrl+p` to see how their card will appear during review. This helps ensure proper Markdown formatting before saving.

### Terminal-Friendly Keyboard Shortcuts

Updated various keyboard shortcuts to avoid conflicts with common terminal operations:
- Replaced `Ctrl+d` with `Ctrl+x d` for deleting cards (avoids EOF signal)
- Replaced `Ctrl+r` with `F2` for renaming decks (avoids reverse history search)
- Replaced `Ctrl+shift+n` with `Ctrl+alt+n` for creating decks (avoids new terminal window)
- Added `F4` as an alternative to `Ctrl+e` for editing
- Used `Alt+arrows` instead of `Ctrl+tab` for textarea navigation

## How to Test

1. Create a new card:
   - Navigate to any deck
   - Press `Ctrl+n` to open the card creation interface
   - Fill in the fields and press `Ctrl+s` to save
   - Verify the card appears in the deck

2. Edit an existing card:
   - Start reviewing cards
   - When viewing a card, press `Ctrl+e` or `F4`
   - Make changes to the card content
   - Press `Ctrl+s` to save
   - Continue reviewing and verify changes are applied

3. Test Markdown preview:
   - While editing a card, add some Markdown formatting (headers, lists, code blocks)
   - Press `Ctrl+p` to preview
   - Verify formatting renders correctly
   - Press `Ctrl+p` again to return to editing

## Screenshots

[Screenshots would be added here showing the card editing interface, preview mode, and navigation between fields]

## Related Issues

- Issue #5: Card Creation and Editing Interface