### PR TITLE
Enhance File Watcher Initialization and Error Handling

### DIFF
--- a/internal/storage/io/file_ops_test.go
+++ b/internal/storage/io/file_ops_test.go
@@ -1,0 +1,294 @@
+// internal/storage/io/file_ops_test.go
+package io
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	testhelp "github.com/DavidMiserak/GoCard/internal/testing"
+)
+
+func TestEnsureDirectoryExists(t *testing.T) {
+	// Create a temporary testing directory
+	tempDir := testhelp.TempDir(t)
+
+	// Test creating a new directory
+	testDir := filepath.Join(tempDir, "test-dir")
+	err := EnsureDirectoryExists(testDir)
+	if err != nil {
+		t.Errorf("Failed to create directory: %v", err)
+	}
+
+	testhelp.AssertFileExists(t, testDir)
+
+	// Test with existing directory (should not error)
+	err = EnsureDirectoryExists(testDir)
+	if err != nil {
+		t.Errorf("Failed on existing directory: %v", err)
+	}
+
+	// Test nested directories
+	nestedDir := filepath.Join(testDir, "nested1", "nested2")
+	err = EnsureDirectoryExists(nestedDir)
+	if err != nil {
+		t.Errorf("Failed to create nested directories: %v", err)
+	}
+
+	testhelp.AssertFileExists(t, nestedDir)
+}
+
+func TestGetAbsolutePath(t *testing.T) {
+	// Test relative path
+	relPath := "test/path"
+	absPath, err := GetAbsolutePath(relPath)
+	if err != nil {
+		t.Errorf("Failed to get absolute path: %v", err)
+	}
+
+	// The absolute path should contain the relative path
+	if filepath.Base(absPath) != filepath.Base(relPath) {
+		t.Errorf("Base of absolute path %s doesn't match base of relative path %s",
+			absPath, relPath)
+	}
+
+	// Test already absolute path
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	absResult, err := GetAbsolutePath(currentDir)
+	if err != nil {
+		t.Errorf("Failed on absolute path: %v", err)
+	}
+
+	if absResult != currentDir {
+		t.Errorf("Expected %s, got %s", currentDir, absResult)
+	}
+}
+
+func TestFileExists(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test file
+	testFile := testhelp.WriteTestFile(t, tempDir, "test.txt", "content")
+
+	// Test existing file
+	if !FileExists(testFile) {
+		t.Errorf("FileExists failed to detect existing file")
+	}
+
+	// Test non-existent file
+	nonExistentFile := filepath.Join(tempDir, "non-existent.txt")
+	if FileExists(nonExistentFile) {
+		t.Errorf("FileExists incorrectly detected non-existent file")
+	}
+
+	// Test directory (should return false as it's not a file)
+	if FileExists(tempDir) {
+		t.Errorf("FileExists incorrectly identified directory as file")
+	}
+}
+
+func TestDirectoryExists(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Test existing directory
+	exists, err := DirectoryExists(tempDir)
+	if err != nil {
+		t.Errorf("DirectoryExists error: %v", err)
+	}
+	if !exists {
+		t.Errorf("DirectoryExists failed to detect existing directory")
+	}
+
+	// Test non-existent directory
+	nonExistentDir := filepath.Join(tempDir, "non-existent-dir")
+	exists, err = DirectoryExists(nonExistentDir)
+	if err != nil {
+		t.Errorf("DirectoryExists error on non-existent dir: %v", err)
+	}
+	if exists {
+		t.Errorf("DirectoryExists incorrectly detected non-existent directory")
+	}
+
+	// Test file (should return false as it's not a directory)
+	testFile := testhelp.WriteTestFile(t, tempDir, "test.txt", "content")
+	exists, err = DirectoryExists(testFile)
+	if err != nil {
+		t.Errorf("DirectoryExists error on file: %v", err)
+	}
+	if exists {
+		t.Errorf("DirectoryExists incorrectly identified file as directory")
+	}
+}
+
+func TestReadFileContent(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test file
+	content := "Hello, World!"
+	testFile := testhelp.WriteTestFile(t, tempDir, "test.txt", content)
+
+	// Read the file
+	readContent, err := ReadFileContent(testFile)
+	if err != nil {
+		t.Errorf("ReadFileContent error: %v", err)
+	}
+
+	if string(readContent) != content {
+		t.Errorf("Expected content %q, got %q", content, string(readContent))
+	}
+
+	// Test non-existent file
+	nonExistentFile := filepath.Join(tempDir, "non-existent.txt")
+	_, err = ReadFileContent(nonExistentFile)
+	if err == nil {
+		t.Errorf("Expected error reading non-existent file, got nil")
+	}
+}
+
+func TestWriteFileContent(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Write to a new file
+	content := "Hello, World!"
+	newFile := filepath.Join(tempDir, "new.txt")
+
+	err := WriteFileContent(newFile, []byte(content))
+	if err != nil {
+		t.Errorf("WriteFileContent error: %v", err)
+	}
+
+	testhelp.AssertFileExists(t, newFile)
+	testhelp.AssertFileContent(t, newFile, content)
+
+	// Write to an existing file (should overwrite)
+	newContent := "New content"
+	err = WriteFileContent(newFile, []byte(newContent))
+	if err != nil {
+		t.Errorf("WriteFileContent error on existing file: %v", err)
+	}
+
+	testhelp.AssertFileContent(t, newFile, newContent)
+
+	// Write to a file in a non-existent directory (should create the directory)
+	nestedFile := filepath.Join(tempDir, "nested", "deep.txt")
+	err = WriteFileContent(nestedFile, []byte(content))
+	if err != nil {
+		t.Errorf("WriteFileContent error with nested directories: %v", err)
+	}
+
+	testhelp.AssertFileExists(t, nestedFile)
+	testhelp.AssertFileContent(t, nestedFile, content)
+}
+
+func TestDeleteFile(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test file
+	testFile := testhelp.WriteTestFile(t, tempDir, "test.txt", "content")
+
+	// Delete the file
+	err := DeleteFile(testFile)
+	if err != nil {
+		t.Errorf("DeleteFile error: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, testFile)
+
+	// Test deleting a non-existent file
+	err = DeleteFile(testFile) // File was already deleted
+	if err == nil {
+		t.Errorf("Expected error deleting non-existent file, got nil")
+	}
+}
+
+func TestMoveFile(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test file
+	content := "Test content"
+	sourceFile := testhelp.WriteTestFile(t, tempDir, "source.txt", content)
+
+	// Move to a new location
+	targetFile := filepath.Join(tempDir, "target.txt")
+	err := MoveFile(sourceFile, targetFile)
+	if err != nil {
+		t.Errorf("MoveFile error: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, sourceFile)
+	testhelp.AssertFileExists(t, targetFile)
+	testhelp.AssertFileContent(t, targetFile, content)
+
+	// Move to a nested directory that doesn't exist yet
+	nestedTarget := filepath.Join(tempDir, "nested", "moved.txt")
+	err = MoveFile(targetFile, nestedTarget)
+	if err != nil {
+		t.Errorf("MoveFile error to nested directory: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, targetFile)
+	testhelp.AssertFileExists(t, nestedTarget)
+	testhelp.AssertFileContent(t, nestedTarget, content)
+}
+
+func TestRenameDirectory(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test directory with a file
+	testDirs := testhelp.CreateTestSubdirs(t, tempDir, "source-dir")
+	sourceDir := testDirs["source-dir"]
+	testhelp.WriteTestFile(t, sourceDir, "test.txt", "content")
+
+	// Rename the directory
+	targetDir := filepath.Join(tempDir, "target-dir")
+	err := RenameDirectory(sourceDir, targetDir)
+	if err != nil {
+		t.Errorf("RenameDirectory error: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, sourceDir)
+	testhelp.AssertFileExists(t, targetDir)
+
+	// Check that the file was moved too
+	targetFile := filepath.Join(targetDir, "test.txt")
+	testhelp.AssertFileExists(t, targetFile)
+
+	// Test renaming to a nested directory that doesn't exist
+	nestedTargetDir := filepath.Join(tempDir, "nested", "renamed-dir")
+	err = RenameDirectory(targetDir, nestedTargetDir)
+	if err != nil {
+		t.Errorf("RenameDirectory error to nested directory: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, targetDir)
+	testhelp.AssertFileExists(t, nestedTargetDir)
+}
+
+func TestDeleteDirectory(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+
+	// Create a test directory with files and subdirectories
+	testDirs := testhelp.CreateTestSubdirs(t, tempDir, "test-dir", "test-dir/subdir")
+	testDir := testDirs["test-dir"]
+
+	testhelp.WriteTestFile(t, testDir, "file1.txt", "content1")
+	testhelp.WriteTestFile(t, testDirs["test-dir/subdir"], "file2.txt", "content2")
+
+	// Delete the directory
+	err := DeleteDirectory(testDir)
+	if err != nil {
+		t.Errorf("DeleteDirectory error: %v", err)
+	}
+
+	testhelp.AssertFileDoesNotExist(t, testDir)
+
+	// Test deleting a non-existent directory
+	err = DeleteDirectory(testDir) // Directory was already deleted
+	if err != nil {
+		t.Errorf("Expected no error when deleting non-existent directory, got: %v", err)
+	}
+}

--- a/internal/storage/io/filesystem.go
+++ b/internal/storage/io/filesystem.go
@@ -1,0 +1,52 @@
+// internal/storage/io/filesystem.go
+package io
+
+import (
+	"os"
+)
+
+// FileSystem defines an interface for filesystem operations
+type FileSystem interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, data []byte, perm os.FileMode) error
+	MkdirAll(path string, perm os.FileMode) error
+	RemoveAll(path string) error
+	Remove(path string) error
+	Rename(oldpath, newpath string) error
+	Stat(path string) (os.FileInfo, error)
+}
+
+// RealFileSystem implements FileSystem using actual OS operations
+type RealFileSystem struct{}
+
+func NewRealFileSystem() *RealFileSystem {
+	return &RealFileSystem{}
+}
+
+func (fs *RealFileSystem) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (fs *RealFileSystem) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+func (fs *RealFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (fs *RealFileSystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (fs *RealFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (fs *RealFileSystem) Rename(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
+func (fs *RealFileSystem) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}

--- a/internal/storage/io/logger_test.go
+++ b/internal/storage/io/logger_test.go
@@ -1,0 +1,233 @@
+// internal/storage/io/logger_test.go
+package io
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNewLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, DEBUG)
+
+	if logger.out != &buf {
+		t.Error("Logger output not set correctly")
+	}
+
+	if logger.level != DEBUG {
+		t.Errorf("Logger level not set correctly, expected %d, got %d", DEBUG, logger.level)
+	}
+
+	if !logger.enabled {
+		t.Error("Logger should be enabled by default")
+	}
+
+	if !logger.timestamp {
+		t.Error("Logger timestamp should be enabled by default")
+	}
+}
+
+func TestLoggerLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		level    LogLevel
+		logFunc  func(logger *Logger, msg string)
+		logLevel LogLevel
+		expected string
+	}{
+		{"Debug at DEBUG level", DEBUG, func(l *Logger, m string) { l.Debug(m) }, DEBUG, "[DEBUG]"},
+		{"Info at DEBUG level", DEBUG, func(l *Logger, m string) { l.Info(m) }, DEBUG, "[INFO]"},
+		{"Warn at DEBUG level", DEBUG, func(l *Logger, m string) { l.Warn(m) }, DEBUG, "[WARN]"},
+		{"Error at DEBUG level", DEBUG, func(l *Logger, m string) { l.Error(m) }, DEBUG, "[ERROR]"},
+
+		{"Debug at INFO level", INFO, func(l *Logger, m string) { l.Debug(m) }, DEBUG, ""}, // Should not log
+		{"Info at INFO level", INFO, func(l *Logger, m string) { l.Info(m) }, INFO, "[INFO]"},
+		{"Warn at INFO level", INFO, func(l *Logger, m string) { l.Warn(m) }, WARN, "[WARN]"},
+		{"Error at INFO level", INFO, func(l *Logger, m string) { l.Error(m) }, ERROR, "[ERROR]"},
+
+		{"Debug at WARN level", WARN, func(l *Logger, m string) { l.Debug(m) }, DEBUG, ""}, // Should not log
+		{"Info at WARN level", WARN, func(l *Logger, m string) { l.Info(m) }, INFO, ""},    // Should not log
+		{"Warn at WARN level", WARN, func(l *Logger, m string) { l.Warn(m) }, WARN, "[WARN]"},
+		{"Error at WARN level", WARN, func(l *Logger, m string) { l.Error(m) }, ERROR, "[ERROR]"},
+
+		{"Debug at ERROR level", ERROR, func(l *Logger, m string) { l.Debug(m) }, DEBUG, ""}, // Should not log
+		{"Info at ERROR level", ERROR, func(l *Logger, m string) { l.Info(m) }, INFO, ""},    // Should not log
+		{"Warn at ERROR level", ERROR, func(l *Logger, m string) { l.Warn(m) }, WARN, ""},    // Should not log
+		{"Error at ERROR level", ERROR, func(l *Logger, m string) { l.Error(m) }, ERROR, "[ERROR]"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := NewLogger(&buf, tc.level)
+			logger.SetTimestamp(false) // Disable timestamp for easier testing
+
+			tc.logFunc(logger, "Test message")
+
+			result := buf.String()
+			if tc.expected == "" {
+				if result != "" {
+					t.Errorf("Expected no output, got: %q", result)
+				}
+			} else {
+				if !strings.Contains(result, tc.expected) {
+					t.Errorf("Expected output containing %q, got: %q", tc.expected, result)
+				}
+				if !strings.Contains(result, "Test message") {
+					t.Errorf("Expected output containing message, got: %q", result)
+				}
+			}
+		})
+	}
+}
+
+func TestSetLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, ERROR)
+
+	// Initially, INFO messages should not be logged
+	logger.Info("Should not appear")
+	if buf.Len() > 0 {
+		t.Errorf("Expected no output, got: %q", buf.String())
+	}
+
+	// Change level to INFO
+	logger.SetLevel(INFO)
+
+	// Now INFO messages should be logged
+	logger.SetTimestamp(false) // Disable timestamp for easier testing
+	logger.Info("Should appear")
+
+	if !strings.Contains(buf.String(), "Should appear") {
+		t.Errorf("Expected message after level change, got: %q", buf.String())
+	}
+}
+
+func TestSetEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, INFO)
+	logger.SetTimestamp(false) // Disable timestamp for easier testing
+
+	// Initially enabled
+	logger.Info("First message")
+	if !strings.Contains(buf.String(), "First message") {
+		t.Errorf("Expected first message, got: %q", buf.String())
+	}
+
+	// Disable logging
+	logger.SetEnabled(false)
+	buf.Reset()
+
+	logger.Info("Should not appear")
+	if buf.Len() > 0 {
+		t.Errorf("Expected no output when disabled, got: %q", buf.String())
+	}
+
+	// Re-enable logging
+	logger.SetEnabled(true)
+	logger.Info("Third message")
+	if !strings.Contains(buf.String(), "Third message") {
+		t.Errorf("Expected third message after re-enabling, got: %q", buf.String())
+	}
+}
+
+func TestSetOutput(t *testing.T) {
+	var buf1 bytes.Buffer
+	var buf2 bytes.Buffer
+
+	logger := NewLogger(&buf1, INFO)
+	logger.SetTimestamp(false) // Disable timestamp for easier testing
+
+	// Log to first buffer
+	logger.Info("First buffer")
+	if !strings.Contains(buf1.String(), "First buffer") {
+		t.Errorf("Expected message in first buffer, got: %q", buf1.String())
+	}
+
+	// Change output to second buffer
+	logger.SetOutput(&buf2)
+	logger.Info("Second buffer")
+
+	if strings.Contains(buf1.String(), "Second buffer") {
+		t.Errorf("First buffer should not contain second message: %q", buf1.String())
+	}
+
+	if !strings.Contains(buf2.String(), "Second buffer") {
+		t.Errorf("Expected message in second buffer, got: %q", buf2.String())
+	}
+}
+
+func TestSetTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, INFO)
+
+	// Default is with timestamp
+	logger.Info("With timestamp")
+	if !strings.Contains(buf.String(), "[") && strings.Contains(buf.String(), ":") {
+		t.Errorf("Expected timestamp in format [HH:MM:SS], got: %q", buf.String())
+	}
+
+	// Disable timestamp
+	buf.Reset()
+	logger.SetTimestamp(false)
+	logger.Info("Without timestamp")
+
+	if strings.Contains(buf.String(), "[") && strings.Contains(buf.String(), ":") &&
+		strings.Contains(buf.String(), "]") && !strings.Contains(buf.String(), "[INFO]") {
+		t.Errorf("Expected no timestamp, got: %q", buf.String())
+	}
+}
+
+func TestGlobalLogging(t *testing.T) {
+	// Save original state
+	origEnabled := loggingEnabled
+	defer func() { loggingEnabled = origEnabled }()
+
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, INFO)
+	logger.SetTimestamp(false)
+
+	// Test global enable/disable
+	EnableLogging(false)
+	logger.Info("Should not appear")
+
+	if buf.Len() > 0 {
+		t.Errorf("Expected no output when globally disabled, got: %q", buf.String())
+	}
+
+	EnableLogging(true)
+	logger.Info("Should appear")
+
+	if !strings.Contains(buf.String(), "Should appear") {
+		t.Errorf("Expected message when globally enabled, got: %q", buf.String())
+	}
+}
+
+func TestSetGlobalLevel(t *testing.T) {
+	// Save original level
+	origLevel := DefaultLogger.level
+	defer func() { DefaultLogger.level = origLevel }()
+
+	var buf bytes.Buffer
+	DefaultLogger.out = &buf
+	DefaultLogger.SetTimestamp(false)
+
+	// Set global level to ERROR
+	SetGlobalLevel(ERROR)
+
+	// INFO should not be logged
+	DefaultLogger.Info("Should not appear")
+	if buf.Len() > 0 {
+		t.Errorf("Expected no output at ERROR level, got: %q", buf.String())
+	}
+
+	// ERROR should be logged
+	DefaultLogger.Error("Should appear")
+	if !strings.Contains(buf.String(), "Should appear") {
+		t.Errorf("Expected error message, got: %q", buf.String())
+	}
+
+	// Restore default logger output to avoid affecting other tests
+	DefaultLogger.out = nil
+}

--- a/internal/storage/io/mock_filesystem.go
+++ b/internal/storage/io/mock_filesystem.go
@@ -1,0 +1,356 @@
+// internal/storage/io/mock_filesystem.go
+package io
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// mockFileInfo implements os.FileInfo for testing
+type mockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (m mockFileInfo) Name() string       { return m.name }
+func (m mockFileInfo) Size() int64        { return m.size }
+func (m mockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m mockFileInfo) ModTime() time.Time { return m.modTime }
+func (m mockFileInfo) IsDir() bool        { return m.isDir }
+func (m mockFileInfo) Sys() interface{}   { return nil }
+
+// MockFileSystem implements FileSystem for testing
+type MockFileSystem struct {
+	mu       sync.RWMutex
+	files    map[string][]byte
+	dirs     map[string]bool
+	fileInfo map[string]mockFileInfo
+
+	// Error maps for simulating failures
+	readErr   map[string]error
+	writeErr  map[string]error
+	mkdirErr  map[string]error
+	removeErr map[string]error
+	renameErr map[string]error
+	statErr   map[string]error
+}
+
+// NewMockFileSystem creates a new mock filesystem
+func NewMockFileSystem() *MockFileSystem {
+	fs := &MockFileSystem{
+		files:     make(map[string][]byte),
+		dirs:      make(map[string]bool),
+		fileInfo:  make(map[string]mockFileInfo),
+		readErr:   make(map[string]error),
+		writeErr:  make(map[string]error),
+		mkdirErr:  make(map[string]error),
+		removeErr: make(map[string]error),
+		renameErr: make(map[string]error),
+		statErr:   make(map[string]error),
+	}
+
+	// Set up the root directory which always exists
+	fs.dirs["/"] = true
+	fs.fileInfo["/"] = mockFileInfo{
+		name:    "/",
+		size:    0,
+		mode:    0755 | os.ModeDir,
+		modTime: time.Now(),
+		isDir:   true,
+	}
+
+	return fs
+}
+
+func (fs *MockFileSystem) ReadFile(path string) ([]byte, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if err, ok := fs.readErr[path]; ok && err != nil {
+		return nil, err
+	}
+
+	data, ok := fs.files[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+
+	return data, nil
+}
+
+func (fs *MockFileSystem) WriteFile(path string, data []byte, perm os.FileMode) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if err, ok := fs.writeErr[path]; ok && err != nil {
+		return err
+	}
+
+	// Create parent directories automatically
+	dir := filepath.Dir(path)
+	fs.createParentDirs(dir)
+
+	fs.files[path] = data
+	fs.fileInfo[path] = mockFileInfo{
+		name:    filepath.Base(path),
+		size:    int64(len(data)),
+		mode:    perm,
+		modTime: time.Now(),
+		isDir:   false,
+	}
+
+	return nil
+}
+
+// Helper method to create parent directories
+func (fs *MockFileSystem) createParentDirs(path string) {
+	if path == "/" || path == "." {
+		return
+	}
+
+	// Recursively create parent directories
+	parent := filepath.Dir(path)
+	if parent != "/" && parent != "." {
+		fs.createParentDirs(parent)
+	}
+
+	// Create this directory if it doesn't exist
+	fs.dirs[path] = true
+	if _, ok := fs.fileInfo[path]; !ok {
+		fs.fileInfo[path] = mockFileInfo{
+			name:    filepath.Base(path),
+			size:    0,
+			mode:    0755 | os.ModeDir,
+			modTime: time.Now(),
+			isDir:   true,
+		}
+	}
+}
+
+func (fs *MockFileSystem) MkdirAll(path string, perm os.FileMode) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if err, ok := fs.mkdirErr[path]; ok && err != nil {
+		return err
+	}
+
+	// Create the directory and all parent directories
+	fs.createParentDirs(path)
+
+	return nil
+}
+
+func (fs *MockFileSystem) RemoveAll(path string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if err, ok := fs.removeErr[path]; ok && err != nil {
+		return err
+	}
+
+	// Don't allow removing the root directory
+	if path == "/" {
+		return errors.New("cannot remove root directory")
+	}
+
+	// Remove the directory and all its contents
+	delete(fs.dirs, path)
+	delete(fs.fileInfo, path)
+
+	// Remove all files and directories that start with this path
+	for filePath := range fs.files {
+		if filePath == path || strings.HasPrefix(filePath, path+"/") {
+			delete(fs.files, filePath)
+			delete(fs.fileInfo, filePath)
+		}
+	}
+
+	for dirPath := range fs.dirs {
+		if dirPath == path || strings.HasPrefix(dirPath, path+"/") {
+			delete(fs.dirs, dirPath)
+			delete(fs.fileInfo, dirPath)
+		}
+	}
+
+	return nil
+}
+
+func (fs *MockFileSystem) Remove(path string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if err, ok := fs.removeErr[path]; ok && err != nil {
+		return err
+	}
+
+	// Don't allow removing the root directory
+	if path == "/" {
+		return errors.New("cannot remove root directory")
+	}
+
+	// Check if it's a file
+	if _, ok := fs.files[path]; ok {
+		delete(fs.files, path)
+		delete(fs.fileInfo, path)
+		return nil
+	}
+
+	// Check if it's a directory
+	if _, ok := fs.dirs[path]; ok {
+		// Check if the directory is empty
+		for filePath := range fs.files {
+			if strings.HasPrefix(filePath, path+"/") {
+				return errors.New("directory not empty")
+			}
+		}
+
+		for dirPath := range fs.dirs {
+			if dirPath != path && strings.HasPrefix(dirPath, path+"/") {
+				return errors.New("directory not empty")
+			}
+		}
+
+		delete(fs.dirs, path)
+		delete(fs.fileInfo, path)
+		return nil
+	}
+
+	return os.ErrNotExist
+}
+
+func (fs *MockFileSystem) Rename(oldpath, newpath string) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	if err, ok := fs.renameErr[oldpath]; ok && err != nil {
+		return err
+	}
+
+	// Create parent directories for the new path
+	dir := filepath.Dir(newpath)
+	fs.createParentDirs(dir)
+
+	// Check if the source exists
+	if fileData, ok := fs.files[oldpath]; ok {
+		// It's a file
+		fs.files[newpath] = fileData
+		fs.fileInfo[newpath] = fs.fileInfo[oldpath]
+		delete(fs.files, oldpath)
+		delete(fs.fileInfo, oldpath)
+		return nil
+	}
+
+	if _, ok := fs.dirs[oldpath]; ok {
+		// It's a directory
+		fs.dirs[newpath] = true
+		fs.fileInfo[newpath] = fs.fileInfo[oldpath]
+		delete(fs.dirs, oldpath)
+		delete(fs.fileInfo, oldpath)
+
+		// Rename all nested files and directories
+		for filePath, fileData := range fs.files {
+			if strings.HasPrefix(filePath, oldpath+"/") {
+				newFilePath := newpath + filePath[len(oldpath):]
+				fs.files[newFilePath] = fileData
+				fs.fileInfo[newFilePath] = fs.fileInfo[filePath]
+				delete(fs.files, filePath)
+				delete(fs.fileInfo, filePath)
+			}
+		}
+
+		for dirPath := range fs.dirs {
+			if dirPath != oldpath && strings.HasPrefix(dirPath, oldpath+"/") {
+				newDirPath := newpath + dirPath[len(oldpath):]
+				fs.dirs[newDirPath] = true
+				fs.fileInfo[newDirPath] = fs.fileInfo[dirPath]
+				delete(fs.dirs, dirPath)
+				delete(fs.fileInfo, dirPath)
+			}
+		}
+
+		return nil
+	}
+
+	return os.ErrNotExist
+}
+
+func (fs *MockFileSystem) Stat(path string) (os.FileInfo, error) {
+	fs.mu.RLock()
+	defer fs.mu.RUnlock()
+
+	if err, ok := fs.statErr[path]; ok && err != nil {
+		return nil, err
+	}
+
+	// Check if it's a file
+	if _, ok := fs.files[path]; ok {
+		info := fs.fileInfo[path]
+		return &info, nil
+	}
+
+	// Check if it's a directory
+	if _, ok := fs.dirs[path]; ok {
+		info := fs.fileInfo[path]
+		return &info, nil
+	}
+
+	return nil, os.ErrNotExist
+}
+
+// Helper methods for testing
+
+// SetupFile adds a file to the mock filesystem for testing
+func (fs *MockFileSystem) SetupFile(path string, content []byte) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	// Create parent directories
+	dir := filepath.Dir(path)
+	fs.createParentDirs(dir)
+
+	fs.files[path] = content
+	fs.fileInfo[path] = mockFileInfo{
+		name:    filepath.Base(path),
+		size:    int64(len(content)),
+		mode:    0644,
+		modTime: time.Now(),
+		isDir:   false,
+	}
+}
+
+// SetupDir adds a directory to the mock filesystem for testing
+func (fs *MockFileSystem) SetupDir(path string) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	fs.createParentDirs(path)
+}
+
+// InjectError sets up an error for a specific operation and path
+func (fs *MockFileSystem) InjectError(op string, path string, err error) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	switch op {
+	case "read":
+		fs.readErr[path] = err
+	case "write":
+		fs.writeErr[path] = err
+	case "mkdir":
+		fs.mkdirErr[path] = err
+	case "remove":
+		fs.removeErr[path] = err
+	case "rename":
+		fs.renameErr[path] = err
+	case "stat":
+		fs.statErr[path] = err
+	}
+}

--- a/internal/storage/io/mock_filesystem_test.go
+++ b/internal/storage/io/mock_filesystem_test.go
@@ -1,0 +1,120 @@
+// internal/storage/io/mock_filesystem_test.go
+package io
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestMockFileSystem(t *testing.T) {
+	fs := NewMockFileSystem()
+
+	// Test writing and reading a file
+	testData := []byte("test data")
+	err := fs.WriteFile("/test/file.txt", testData, 0644)
+	if err != nil {
+		t.Errorf("WriteFile error: %v", err)
+	}
+
+	readData, err := fs.ReadFile("/test/file.txt")
+	if err != nil {
+		t.Errorf("ReadFile error: %v", err)
+	}
+
+	if string(readData) != string(testData) {
+		t.Errorf("Expected %q, got %q", testData, readData)
+	}
+
+	// Test parent directory was created automatically
+	info, err := fs.Stat("/test")
+	if err != nil {
+		t.Errorf("Stat error on directory: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Error("Expected IsDir() to be true for directory")
+	}
+
+	// Test explicitly creating directories
+	err = fs.MkdirAll("/test/dir1/dir2", 0755)
+	if err != nil {
+		t.Errorf("MkdirAll error: %v", err)
+	}
+
+	// Test Stat on directory
+	info, err = fs.Stat("/test/dir1")
+	if err != nil {
+		t.Errorf("Stat error on directory: %v", err)
+	}
+
+	if !info.IsDir() {
+		t.Error("Expected IsDir() to be true for directory")
+	}
+
+	// Test Stat on file
+	info, err = fs.Stat("/test/file.txt")
+	if err != nil {
+		t.Errorf("Stat error on file: %v", err)
+	}
+
+	if info.IsDir() {
+		t.Error("Expected IsDir() to be false for file")
+	}
+
+	if info.Size() != int64(len(testData)) {
+		t.Errorf("Expected size %d, got %d", len(testData), info.Size())
+	}
+
+	// Test Remove
+	err = fs.Remove("/test/file.txt")
+	if err != nil {
+		t.Errorf("Remove error: %v", err)
+	}
+
+	_, err = fs.Stat("/test/file.txt")
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected ErrNotExist after remove, got %v", err)
+	}
+
+	// Test Rename
+	fs.WriteFile("/test/old.txt", []byte("old data"), 0644)
+	err = fs.Rename("/test/old.txt", "/test/dir1/new.txt")
+	if err != nil {
+		t.Errorf("Rename error: %v", err)
+	}
+
+	_, err = fs.Stat("/test/old.txt")
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected ErrNotExist for old file after rename, got %v", err)
+	}
+
+	_, err = fs.Stat("/test/dir1/new.txt")
+	if err != nil {
+		t.Errorf("Stat error on renamed file: %v", err)
+	}
+
+	// Test RemoveAll
+	fs.WriteFile("/test/dir1/file1.txt", []byte("file1"), 0644)
+	fs.WriteFile("/test/dir1/dir2/file2.txt", []byte("file2"), 0644)
+
+	err = fs.RemoveAll("/test/dir1")
+	if err != nil {
+		t.Errorf("RemoveAll error: %v", err)
+	}
+
+	_, err = fs.Stat("/test/dir1")
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected ErrNotExist for directory after RemoveAll, got %v", err)
+	}
+
+	// Test error injection
+	expectedErr := errors.New("injected error")
+	fs.SetupFile("/error/file.txt", []byte("data"))
+	fs.InjectError("read", "/error/file.txt", expectedErr)
+
+	_, err = fs.ReadFile("/error/file.txt")
+	if err != expectedErr {
+		t.Errorf("Expected injected error, got %v", err)
+	}
+}

--- a/internal/storage/io/watcher.go
+++ b/internal/storage/io/watcher.go
@@ -32,6 +32,11 @@ type FileWatcher struct {
 
 // NewFileWatcher creates a new FileWatcher for the given root directory
 func NewFileWatcher(rootDir string) (*FileWatcher, error) {
+	// Check if the directory exists
+	if _, err := os.Stat(rootDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("directory does not exist: %s", rootDir)
+	}
+
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file watcher: %w", err)

--- a/internal/storage/io/watcher_test.go
+++ b/internal/storage/io/watcher_test.go
@@ -1,0 +1,232 @@
+// internal/storage/io/watcher_test.go
+package io
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	testhelp "github.com/DavidMiserak/GoCard/internal/testing"
+)
+
+// mockFsnotifyWatcher is a mock implementation of fsnotify.Watcher
+type mockFsnotifyWatcher struct {
+	events       chan FileEvent
+	errors       chan error
+	addedPaths   []string
+	removedPaths []string
+	closed       bool
+}
+
+func newMockFsnotifyWatcher() *mockFsnotifyWatcher {
+	return &mockFsnotifyWatcher{
+		events:       make(chan FileEvent, 10),
+		errors:       make(chan error, 10),
+		addedPaths:   []string{},
+		removedPaths: []string{},
+		closed:       false,
+	}
+}
+
+func (m *mockFsnotifyWatcher) Add(path string) error {
+	if m.closed {
+		return errors.New("watcher is closed")
+	}
+	m.addedPaths = append(m.addedPaths, path)
+	return nil
+}
+
+func (m *mockFsnotifyWatcher) Remove(path string) error {
+	if m.closed {
+		return errors.New("watcher is closed")
+	}
+	m.removedPaths = append(m.removedPaths, path)
+	return nil
+}
+
+func (m *mockFsnotifyWatcher) Close() error {
+	if m.closed {
+		return errors.New("watcher already closed")
+	}
+	m.closed = true
+	close(m.events)
+	close(m.errors)
+	return nil
+}
+
+// Mock creation function to replace the real fsnotify.NewWatcher
+func mockNewFsnotifyWatcher() (*mockFsnotifyWatcher, error) {
+	return newMockFsnotifyWatcher(), nil
+}
+
+// TestNewFileWatcher tests the creation of a new file watcher
+func TestNewFileWatcher(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := testhelp.TempDir(t)
+
+	// Test with valid directory
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Errorf("NewFileWatcher error with valid directory: %v", err)
+	}
+
+	if watcher == nil {
+		t.Fatal("Expected watcher to be created, got nil")
+	}
+
+	// Clean up
+	watcher.Stop()
+
+	// Test with non-existent directory
+	nonExistentDir := filepath.Join(tempDir, "non-existent")
+	watcher, err = NewFileWatcher(nonExistentDir)
+	if err == nil {
+		t.Error("Expected error with non-existent directory, got nil")
+		if watcher != nil {
+			watcher.Stop()
+		}
+	}
+}
+
+func TestSetLogger(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	var buf bytes.Buffer
+	logger := NewLogger(&buf, DEBUG)
+
+	// Set the logger
+	watcher.SetLogger(logger)
+
+	// Verify the logger was set (indirectly)
+	if watcher.logger == nil {
+		t.Error("Logger was not set")
+	}
+}
+
+func TestStartStop(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+
+	// Test starting
+	err = watcher.Start()
+	if err != nil {
+		t.Errorf("Failed to start watcher: %v", err)
+	}
+
+	if !watcher.isRunning {
+		t.Error("Watcher should be running after Start()")
+	}
+
+	// Test starting again (should error)
+	err = watcher.Start()
+	if err == nil {
+		t.Error("Expected error when starting twice")
+	}
+
+	// Test stopping
+	err = watcher.Stop()
+	if err != nil {
+		t.Errorf("Failed to stop watcher: %v", err)
+	}
+
+	if watcher.isRunning {
+		t.Error("Watcher should not be running after Stop()")
+	}
+}
+
+func TestEventsAndErrors(t *testing.T) {
+	tempDir := testhelp.TempDir(t)
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	// Test Events() method
+	events := watcher.Events()
+	if events == nil {
+		t.Error("Events() returned nil channel")
+	}
+
+	// Test Errors() method
+	errors := watcher.Errors()
+	if errors == nil {
+		t.Error("Errors() returned nil channel")
+	}
+}
+
+// TestAddDirectory tests adding directories to the watcher
+func TestAddDirectory(t *testing.T) {
+	// This is a more complex test that would ideally use dependency injection
+	// For simplicity in this example, we'll test the actual function with real directories
+
+	tempDir := testhelp.TempDir(t)
+
+	// Create nested directories
+	testhelp.CreateTestSubdirs(t, tempDir, "subdir1", "subdir1/nested")
+
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	// Since addDirectory is private, we need to test it through Start()
+	// This will call addDirectory internally
+	err = watcher.Start()
+	if err != nil {
+		t.Fatalf("Failed to start watcher: %v", err)
+	}
+
+	// Add a new directory after starting
+	newDir := filepath.Join(tempDir, "new-dir")
+	err = os.MkdirAll(newDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create new directory: %v", err)
+	}
+
+	// Give the file system watcher some time to detect the new directory
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestRemoveDirectory(t *testing.T) {
+	// Similar to TestAddDirectory, this would ideally use a mock
+	// but we'll test with real directories
+
+	tempDir := testhelp.TempDir(t)
+
+	// Create nested directories
+	dirs := testhelp.CreateTestSubdirs(t, tempDir, "subdir1", "subdir1/nested")
+
+	watcher, err := NewFileWatcher(tempDir)
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer watcher.Stop()
+
+	// Start the watcher
+	err = watcher.Start()
+	if err != nil {
+		t.Fatalf("Failed to start watcher: %v", err)
+	}
+
+	// Remove a directory
+	err = os.RemoveAll(dirs["subdir1"])
+	if err != nil {
+		t.Fatalf("Failed to remove directory: %v", err)
+	}
+
+	// Give the file system watcher some time to detect the removal
+	time.Sleep(100 * time.Millisecond)
+}

--- a/internal/testing/helpers.go
+++ b/internal/testing/helpers.go
@@ -1,0 +1,94 @@
+// internal/testing/helpers.go
+package testing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TempDir creates and manages a temporary directory for testing
+func TempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "gocard-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	// Register cleanup to run after the test completes
+	t.Cleanup(func() {
+		os.RemoveAll(dir)
+	})
+
+	return dir
+}
+
+// WriteTestFile creates a test file with the given content
+func WriteTestFile(t *testing.T, dir, filename, content string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, filename)
+	err := os.WriteFile(path, []byte(content), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	return path
+}
+
+// CreateTestSubdirs creates a test directory structure
+func CreateTestSubdirs(t *testing.T, baseDir string, subDirs ...string) map[string]string {
+	t.Helper()
+
+	paths := make(map[string]string)
+	for _, sub := range subDirs {
+		path := filepath.Join(baseDir, sub)
+		err := os.MkdirAll(path, 0755)
+		if err != nil {
+			t.Fatalf("Failed to create subdirectory %s: %v", sub, err)
+		}
+		paths[sub] = path
+	}
+
+	return paths
+}
+
+// AssertFileExists checks if a file exists
+func AssertFileExists(t *testing.T, path string) {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		t.Errorf("Expected file to exist at %s, but it doesn't", path)
+	} else if err != nil {
+		t.Errorf("Error checking file existence at %s: %v", path, err)
+	}
+}
+
+// AssertFileDoesNotExist checks that a file doesn't exist
+func AssertFileDoesNotExist(t *testing.T, path string) {
+	t.Helper()
+
+	_, err := os.Stat(path)
+	if err == nil {
+		t.Errorf("Expected file to not exist at %s, but it does", path)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("Error checking file non-existence at %s: %v", path, err)
+	}
+}
+
+// AssertFileContent checks that a file has the expected content
+func AssertFileContent(t *testing.T, path, expected string) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Errorf("Failed to read file at %s: %v", path, err)
+		return
+	}
+
+	if string(content) != expected {
+		t.Errorf("File content mismatch.\nExpected: %s\nActual: %s", expected, string(content))
+	}
+}


### PR DESCRIPTION
This pull request improves the file watcher initialization process by adding robust directory existence checking and more informative error handling. The changes ensure that the `NewFileWatcher` function validates the input directory before attempting to create a watcher, preventing potential runtime errors.

## Changes
- Added directory existence check in `NewFileWatcher`
- Return descriptive error when directory does not exist
- Improved error handling for file watcher creation
- Enhanced test coverage for file watcher initialization

## Motivation
The current implementation of the file watcher did not verify the existence of the target directory before attempting to create a watcher. This could lead to unexpected runtime errors and make debugging more difficult. By adding an explicit check and returning a clear error message, we improve the robustness and usability of the file watching mechanism.

## Details
- Modified `NewFileWatcher` in `internal/storage/io/watcher.go`
- Updated `TestNewFileWatcher` in `internal/storage/io/watcher_test.go`
- Used `os.Stat()` and `os.IsNotExist()` for directory validation
- Provided descriptive error message for non-existent directories

## Testing
- Existing test cases now pass
- Added validation for directory existence during watcher creation
- Ensured error is returned for non-existent directories

## Checklist
- [x] Added directory existence check
- [x] Improved error handling
- [x] Updated tests
- [x] Verified test coverage
- [ ] Added documentation (optional)

## Potential Future Improvements
- Consider adding more comprehensive validation for directory permissions
- Potentially add logging for directory existence failures

## Related Issues
- Relates to file system robustness
- Improves error handling in file watching mechanism