### PR TITLE
Update card format to use explicit Question/Answer sections

### DIFF
--- a/internal/service/storage/filesystem_test.go
+++ b/internal/service/storage/filesystem_test.go
@@ -60,31 +60,30 @@ func createSampleDeckStructure(baseDir string) error {
 	cardContents := map[string]string{
 		filepath.Join(baseDir, "Programming", "Go", "concurrency.md"): `---
 title: Go Concurrency
-tags:
-  - go
-  - programming
-  - concurrency
+tags: [go,programming,concurrency]
 difficulty: 2
 last_reviewed: 2023-01-01
 review_interval: 7
 ---
-# What is the difference between a goroutine and a thread?
+# Go Concurrency
 
----
+## Question
+What is the difference between a goroutine and a thread?
 
+## Answer
 Goroutines are lighter weight than threads.
 `,
 		filepath.Join(baseDir, "Languages", "Spanish", "verbs.md"): `---
 title: Spanish Verbs
-tags:
-  - spanish
-  - language
+tags: [spanish,language,grammar]
 difficulty: 3
 ---
-# What is the conjugation of "hablar" in present tense?
+# Spanish Verbs
 
----
+## Question
+What is the conjugation of "hablar" in present tense?
 
+## Answer
 yo hablo
 tú hablas
 él/ella/usted habla
@@ -132,19 +131,17 @@ func TestLoadCard(t *testing.T) {
 	// Create a sample card file
 	cardContent := `---
 title: Test Card
-tags:
-  - test
-  - sample
+tags: [test,sample]
 difficulty: 3
 last_reviewed: 2023-01-15
 review_interval: 14
 ---
-# Test Question
+# Test Card
 
+## Question
 This is a test question.
 
----
-
+## Answer
 This is the answer.
 `
 	cardPath, err := createSampleCardFile(tempDir, "test-card.md", cardContent)
@@ -176,8 +173,8 @@ This is the answer.
 	}
 
 	// Check question and answer extraction
-	if !strings.Contains(card.Question, "Test Question") {
-		t.Errorf("expected Question to contain 'Test Question', got '%s'", card.Question)
+	if !strings.Contains(card.Question, "This is a test question") {
+		t.Errorf("expected Question to contain 'This is a test question', got '%s'", card.Question)
 	}
 
 	if !strings.Contains(card.Answer, "This is the answer") {
@@ -210,16 +207,15 @@ func TestUpdateCardMetadata(t *testing.T) {
 	// Create a sample card file
 	cardContent := `---
 title: Test Card
-tags:
-  - test
+tags: [test]
 difficulty: 3
 ---
-# Question
+# Test Card
 
+## Question
 What is this test for?
 
----
-
+## Answer
 To test UpdateCardMetadata.
 `
 	cardPath, err := createSampleCardFile(tempDir, "update-test.md", cardContent)

--- a/internal/service/storage/markdown_format_test.go
+++ b/internal/service/storage/markdown_format_test.go
@@ -1,0 +1,116 @@
+// internal/service/storage/new_format_test.go
+package storage
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadCardWithNewFormat(t *testing.T) {
+	fs, tempDir, cleanup := setupFileSystemTest(t)
+	defer cleanup()
+
+	// Test card with new ## Question and ## Answer format
+	newFormatContent := `---
+title: Spanish Greetings
+tags: [spanish,vocabulary,language-learning]
+created: 2025-03-22
+last_reviewed: 2025-03-22
+review_interval: 0
+difficulty: 3
+---
+# Spanish Greetings and Introductions
+
+## Question
+
+What are the common Spanish greetings and introductions?
+
+## Answer
+
+### Formal Greetings
+- Buenos días (Good morning)
+- Buenas tardes (Good afternoon)
+- Buenas noches (Good evening/night)
+
+### Informal Greetings
+- ¡Hola! (Hello!)
+- ¿Qué tal? (How's it going?)
+- ¿Cómo estás? (How are you?)
+`
+
+	// Create the card file
+	cardPath, err := createSampleCardFile(tempDir, "new-format-test.md", newFormatContent)
+	if err != nil {
+		t.Fatalf("failed to create sample card file: %v", err)
+	}
+
+	// Load the card
+	card, err := fs.LoadCard(cardPath)
+	if err != nil {
+		t.Fatalf("LoadCard() error = %v", err)
+	}
+
+	// Verify card properties
+	if card.Title != "Spanish Greetings" {
+		t.Errorf("expected Title to be 'Spanish Greetings', got '%s'", card.Title)
+	}
+
+	// Verify tags were parsed correctly from array format
+	expectedTags := []string{"spanish", "vocabulary", "language-learning"}
+	if len(card.Tags) != len(expectedTags) {
+		t.Errorf("expected %d tags, got %d: %v", len(expectedTags), len(card.Tags), card.Tags)
+	} else {
+		for i, tag := range expectedTags {
+			if i < len(card.Tags) && card.Tags[i] != tag {
+				t.Errorf("expected tag[%d] to be '%s', got '%s'", i, tag, card.Tags[i])
+			}
+		}
+	}
+
+	// Check question extraction with ## Question format
+	if !contains(card.Question, "What are the common Spanish greetings and introductions?") {
+		t.Errorf("Question not extracted correctly: %s", card.Question)
+	}
+
+	// Check answer extraction with ## Answer format
+	if !contains(card.Answer, "Formal Greetings") || !contains(card.Answer, "Informal Greetings") {
+		t.Errorf("Answer not extracted correctly: %s", card.Answer)
+	}
+
+	// Test card without title in frontmatter
+	untitledContent := `---
+tags: [test]
+difficulty: 2
+---
+# This Is My Card Title
+
+## Question
+What happens when there's no title in frontmatter?
+
+## Answer
+The filename is used as the title.
+`
+
+	// Create the card file without title in frontmatter
+	untitledPath, err := createSampleCardFile(tempDir, "untitled-test.md", untitledContent)
+	if err != nil {
+		t.Fatalf("failed to create untitled card file: %v", err)
+	}
+
+	// Load the card
+	untitledCard, err := fs.LoadCard(untitledPath)
+	if err != nil {
+		t.Fatalf("LoadCard() error for untitled = %v", err)
+	}
+
+	// Filename should be used as title
+	expectedTitle := "untitled-test"
+	if untitledCard.Title != expectedTitle {
+		t.Errorf("expected Title to be '%s' for untitled card, got '%s'", expectedTitle, untitledCard.Title)
+	}
+}
+
+// Helper function to check if a string contains a substring
+func contains(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/internal/ui/tui/deck_list_model.go
+++ b/internal/ui/tui/deck_list_model.go
@@ -91,50 +91,101 @@ func (m *DeckListModel) createDefaultDecks() tea.Cmd {
 				path: filepath.Join(goDeckPath, "concurrency.md"),
 				content: []byte(`---
 title: Go Concurrency
-tags:
-  - go
-  - programming
+tags: [go,programming,concurrency]
 difficulty: 3
 ---
-# What is a goroutine?
+# Go Concurrency
 
----
+## Question
+
+What is a goroutine?
+
+## Answer
 
 A goroutine is a lightweight thread managed by the Go runtime. It allows concurrent execution of functions.
+
+Key features:
+- Much lighter weight than OS threads
+- Managed by Go's runtime scheduler
+- Can scale to thousands or millions in a single program
+- Created with the 'go' keyword before a function call
 `),
 			},
 			{
 				path: filepath.Join(pythonDeckPath, "list_comprehensions.md"),
 				content: []byte(`---
 title: Python List Comprehensions
-tags:
-  - python
-  - programming
+tags: [python,programming,data-structures]
 difficulty: 2
 ---
-# What is a list comprehension?
+# Python List Comprehensions
 
----
+## Question
+
+What is a list comprehension?
+
+## Answer
 
 A list comprehension is a concise way to create lists in Python, offering a compact alternative to using for loops.
+
+### Basic syntax:
+` + "```python" + `
+[expression for item in iterable]
+` + "```" + `
+
+### With conditional filtering:
+` + "```python" + `
+[expression for item in iterable if condition]
+` + "```" + `
+
+### Example:
+` + "```python" + `
+# Create a list of squares
+squares = [x**2 for x in range(10)]
+# Result: [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
+
+# Only even numbers
+even_squares = [x**2 for x in range(10) if x % 2 == 0]
+# Result: [0, 4, 16, 36, 64]
+` + "```" + `
 `),
 			},
 			{
 				path: filepath.Join(spanishDeckPath, "basic_verbs.md"),
 				content: []byte(`---
 title: Basic Spanish Verbs
-tags:
-  - spanish
-  - languages
+tags: [spanish,language,grammar,verbs]
 difficulty: 1
 ---
-# What are the basic forms of "ser" and "estar"?
+# Basic Spanish Verbs
 
----
+## Question
+
+What are the basic forms of "ser" and "estar"?
+
+## Answer
 
 "Ser" and "estar" are both forms of "to be" in Spanish, but they are used differently:
-- "Ser" is used for permanent characteristics
-- "Estar" is used for temporary states or locations
+
+### Ser (permanent qualities):
+- Yo soy (I am)
+- Tú eres (You are)
+- Él/Ella/Usted es (He/She/You formal is)
+- Nosotros/as somos (We are)
+- Vosotros/as sois (You all are - Spain)
+- Ellos/Ellas/Ustedes son (They/You all are)
+
+### Estar (temporary states or locations):
+- Yo estoy (I am)
+- Tú estás (You are)
+- Él/Ella/Usted está (He/She/You formal is)
+- Nosotros/as estamos (We are)
+- Vosotros/as estáis (You all are - Spain)
+- Ellos/Ellas/Ustedes están (They/You all are)
+
+### Usage:
+- Use "ser" for: identity, occupation, nationality, time, characteristics
+- Use "estar" for: location, temporary conditions, ongoing actions
 `),
 			},
 		}


### PR DESCRIPTION
### Overview
This PR updates GoCard to use a more structured card format with explicit `## Question` and `## Answer` sections instead of the previous separator-based format. The new format improves readability, especially for complex content, and better supports Markdown formatting.

### Changes
- **New Card Format**: Changed from `---` separator to explicit `## Question` and `## Answer` sections
- **Tag Format Support**: Added support for array-style tags: `tags: [tag1,tag2,tag3]`
- **Parser Update**: Rewrote the parsing logic in `filesystem.go` to handle the new format
- **Test Coverage**: Updated existing tests and added new tests for the enhanced format
- **Default Cards**: Updated the default card generator to use the new format

### Modified Files
- `internal/service/storage/filesystem.go` - Updated parsing logic
- `internal/service/storage/filesystem_test.go` - Updated test cases
- `internal/service/storage/new_format_test.go` - Added new tests 
- `internal/ui/tui/deck_list_model.go` - Updated default card generator

### Breaking Changes
⚠️ This change drops support for the old format. Existing cards will need to be updated to use the new format with `## Question` and `## Answer` sections.

### New Card Format Example
```markdown
---
title: Card Title
tags: [tag1,tag2,tag3]
created: 2025-03-26
last_reviewed: 2025-03-26
review_interval: 0
difficulty: 0
---

# Card Title

## Question

Your question goes here.

## Answer

Your answer goes here.
```

### Testing Instructions
1. Run the unit tests: `go test ./internal/service/storage`
2. Delete any existing cards and run the application to test default card generation
3. Test reviewing cards with the new format
4. Ensure searching and tagging functionality works with the new format

### Motivation
This format change improves the readability of cards and makes it easier to include complex content like tables, code examples, and nested sections within questions and answers.